### PR TITLE
Remove empty hyperlink to exercise todo list

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,6 @@ Please read about how to [get involved in an Exercism track](https://github.com/
 We welcome pull requests of all kinds. No contribution is too small, particularly those that provide fixes and improvements to existing exercises. Note that this track's exercises must conform to the [Exercism-wide standards](https://github.com/exercism/docs/tree/master/language-tracks/exercises), but if you're unsure about how to make a change, then open a GitHub issue, and we'll discuss it.
 
 
-A list of missing exercise can be found at: http://exercism.io/languages/pharo/todo
-
-
 ### Conventions
 
 - We use [SUnit](https://en.wikipedia.org/wiki/SUnit) (the original xUnit libary) and no additional 3rd-party-frameworks.


### PR DESCRIPTION
This link redirects to a generic Exercism contribution page. The similar URL patterns for other language tracks redirect to the same generic page. I think this may have been an intended feature that was not implemented in the current version of Exercism. An alternative could be a TODO.md document in the /docs directory of this repo.