### PR TITLE
Improve the menu's for exercism by cleaning up to use instance side methods

### DIFF
--- a/dev/src/ExercismTools/ClyExercismExerciseCommand.class.st
+++ b/dev/src/ExercismTools/ClyExercismExerciseCommand.class.st
@@ -14,9 +14,18 @@ ClyExercismExerciseCommand class >> canBeExecutedInContext: aToolContext [
 ]
 
 { #category : #activation }
+ClyExercismExerciseCommand class >> contextMenuOrder [
+	<classAnnotationDependency>
+	
+		^1
+]
+
+{ #category : #activation }
 ClyExercismExerciseCommand class >> packageContextMenuActivation [
 	<classAnnotation>
+	
 	^ CmdContextMenuActivation
 		byItemOf: ClyExercismMenuGroup
+		order: self contextMenuOrder
 		for: ClyTaggedClassGroup asCalypsoItemContext
 ]

--- a/dev/src/ExercismTools/ClyExercismMetaDataCommand.class.st
+++ b/dev/src/ExercismTools/ClyExercismMetaDataCommand.class.st
@@ -4,8 +4,13 @@ Class {
 	#category : #'ExercismTools-Menus'
 }
 
+{ #category : #activation }
+ClyExercismMetaDataCommand class >> contextMenuOrder [
+		^100
+]
+
 { #category : #accessing }
-ClyExercismMetaDataCommand class >> defaultMenuItemName [
+ClyExercismMetaDataCommand >> defaultMenuItemName [
 	^'View MetaData (debug)'
 ]
 

--- a/dev/src/ExercismTools/ClyExercismPkgFetchCommand.class.st
+++ b/dev/src/ExercismTools/ClyExercismPkgFetchCommand.class.st
@@ -1,22 +1,17 @@
 Class {
-	#name : #ClyExercismFetchCommand,
+	#name : #ClyExercismPkgFetchCommand,
 	#superclass : #ClyExercismCommand,
 	#category : #'ExercismTools-Menus'
 }
 
 { #category : #testing }
-ClyExercismFetchCommand class >> canBeExecutedInContext: aToolContext [
+ClyExercismPkgFetchCommand class >> canBeExecutedInContext: aToolContext [
 	^ (super canBeExecutedInContext: aToolContext)
 		and: [ self isExercismTagIn: aToolContext ]
 ]
 
 { #category : #testing }
-ClyExercismFetchCommand class >> defaultMenuItemName [
-	^'Fetch new exercise...'
-]
-
-{ #category : #testing }
-ClyExercismFetchCommand class >> packageContextMenuActivation [
+ClyExercismPkgFetchCommand class >> packageContextMenuActivation [
 	<classAnnotation>
 	
 	^ CmdContextMenuActivation
@@ -24,7 +19,17 @@ ClyExercismFetchCommand class >> packageContextMenuActivation [
 		for: RPackage asCalypsoItemContext
 ]
 
+{ #category : #testing }
+ClyExercismPkgFetchCommand >> defaultMenuIconName [
+	^#book
+]
+
+{ #category : #testing }
+ClyExercismPkgFetchCommand >> defaultMenuItemName [
+	^'Fetch new exercise...'
+]
+
 { #category : #execution }
-ClyExercismFetchCommand >> execute [
+ClyExercismPkgFetchCommand >> execute [
 	ExercismManager default fetchFromExercismTo: self packages first
 ]

--- a/dev/src/ExercismTools/ClyExercismProgressCommand.class.st
+++ b/dev/src/ExercismTools/ClyExercismProgressCommand.class.st
@@ -4,8 +4,18 @@ Class {
 	#category : #'ExercismTools-Menus'
 }
 
+{ #category : #activation }
+ClyExercismProgressCommand class >> contextMenuOrder [
+		^5
+]
+
+{ #category : #execution }
+ClyExercismProgressCommand >> defaultMenuIconName [
+	^#home
+]
+
 { #category : #accessing }
-ClyExercismProgressCommand class >> defaultMenuItemName [
+ClyExercismProgressCommand >> defaultMenuItemName [
 	^'View Track Progress'
 ]
 

--- a/dev/src/ExercismTools/ClyExercismSubmitCommand.class.st
+++ b/dev/src/ExercismTools/ClyExercismSubmitCommand.class.st
@@ -5,8 +5,23 @@ Class {
 }
 
 { #category : #activation }
-ClyExercismSubmitCommand class >> defaultMenuItemName [
+ClyExercismSubmitCommand class >> contextMenuOrder [
+		^1
+]
+
+{ #category : #activation }
+ClyExercismSubmitCommand >> defaultMenuIconName [
+	^#smallExport
+]
+
+{ #category : #activation }
+ClyExercismSubmitCommand >> defaultMenuItemName [
 	^'Submit exercise...'
+]
+
+{ #category : #execution }
+ClyExercismSubmitCommand >> description [ 
+	^'Sumbit your proposed solution to Exercism for mentor review'
 ]
 
 { #category : #execution }

--- a/dev/src/ExercismTools/ClyExercismTagFetchCommand.class.st
+++ b/dev/src/ExercismTools/ClyExercismTagFetchCommand.class.st
@@ -1,0 +1,30 @@
+Class {
+	#name : #ClyExercismTagFetchCommand,
+	#superclass : #ClyExercismExerciseCommand,
+	#category : #'ExercismTools-Menus'
+}
+
+{ #category : #activation }
+ClyExercismTagFetchCommand class >> contextMenuOrder [
+		^10
+]
+
+{ #category : #accessing }
+ClyExercismTagFetchCommand >> defaultMenuIconName [
+	^#book
+]
+
+{ #category : #testing }
+ClyExercismTagFetchCommand >> defaultMenuItemName [
+	^'Fetch new exercise...'
+]
+
+{ #category : #execution }
+ClyExercismTagFetchCommand >> description [ 
+	^'Fetch a named exercise to begin solving it'
+]
+
+{ #category : #execution }
+ClyExercismTagFetchCommand >> execute [
+	ExercismManager default fetchFromExercismTo: self packages first
+]


### PR DESCRIPTION
… improve the ordering and provide a fetch menu at both the exercise and project level (so its less annoying to click on the right place.  *we may change fetch on the exercise level to fetch next as we could have the meta info in the image).

(cherry picked from commit 5a0b684)

This PR is a second attempt to do this cleanly due to forked repo shenanigans