### PR TITLE
Scan solutions for known selectors that the student was asked to avoid

### DIFF
--- a/dev/src/Exercism/LeapTest.class.st
+++ b/dev/src/Exercism/LeapTest.class.st
@@ -89,6 +89,11 @@ LeapTest >> setUp [
 ]
 
 { #category : #test }
+LeapTest >> testMisuseOfSelector [
+	self verifySolution: leapCalculator class avoidsSelector: #isLeapYear
+]
+
+{ #category : #test }
 LeapTest >> testYearDivisibleBy100NotDivisibleBy400InCommonYear [
 	| result |
 

--- a/dev/src/Exercism/ReverseStringTest.class.st
+++ b/dev/src/Exercism/ReverseStringTest.class.st
@@ -110,3 +110,8 @@ ReverseStringTest >> testAnEmptyString [
 	result := reverseStringCalculator reverseValue: '' .
 	self assert: result equals: ''
 ]
+
+{ #category : #test }
+ReverseStringTest >> testMisuseOfSelector [
+	self verifySolution: reverseStringCalculator class avoidsSelector: #reverse
+]

--- a/dev/src/ExercismTools/ExercismTest.class.st
+++ b/dev/src/ExercismTools/ExercismTest.class.st
@@ -109,3 +109,12 @@ ExercismTest class >> wordifiedName [
 						ifTrue: [ aStream space ].
 					aStream nextPut: char ] ]
 ]
+
+{ #category : #test }
+ExercismTest >> verifySolution: aClass avoidsSelector: aSelector [
+	| badSelector |
+ 
+	badSelector := aClass methods detect: [ :m | m ast sentMessages includes: aSelector ] ifNone: [ ^self ].
+	
+	self fail: badSelector name, ' uses restricted method #', aSelector
+]

--- a/dev/src/ExercismTools/ExercismTest.class.st
+++ b/dev/src/ExercismTools/ExercismTest.class.st
@@ -116,5 +116,5 @@ ExercismTest >> verifySolution: aClass avoidsSelector: aSelector [
  
 	badSelector := aClass methods detect: [ :m | m ast sentMessages includes: aSelector ] ifNone: [ ^self ].
 	
-	self fail: badSelector name, ' uses restricted method #', aSelector
+	self fail: 'Your #', badSelector name, ' uses a library method #', aSelector, ' - try writing a solution that avoids it'
 ]

--- a/dev/src/ExercismTools/ExercismTestTest.class.st
+++ b/dev/src/ExercismTools/ExercismTestTest.class.st
@@ -24,6 +24,16 @@ ExercismTestTest >> testSlug [
 ]
 
 { #category : #tests }
+ExercismTestTest >> testVerifySelectorUsageDetection [
+	self
+		should: [ ExercismTest new
+				verifySolution: ExercismTestTest
+				avoidsSelector: #assert:equals: ]
+		raise: TestFailure
+		description: 'Should signal a TestFailure for detected selector usage'
+]
+
+{ #category : #tests }
 ExercismTestTest >> testWordifiedName [
 	self assert: ExercismTest wordifiedName equals: 'Exercism'.
 	self assert: HelloWorldTest wordifiedName equals: 'Hello World'


### PR DESCRIPTION
This fixes #142 and provides a generic way for tests to scan for misused selectors.