### PR TITLE
Fix missing "View Summary" menu item in mentor menu

### DIFF
--- a/dev/src/ExercismDev/ClyExercismReviewSummaryCommand.class.st
+++ b/dev/src/ExercismDev/ClyExercismReviewSummaryCommand.class.st
@@ -27,6 +27,15 @@ ClyExercismReviewSummaryCommand class >> contextMenuOrder [
 ]
 
 { #category : #activation }
+ClyExercismReviewSummaryCommand class >> isExercismTagIn: aToolContext [
+
+	^ aToolContext selectedClassItems
+		detect: [ :any | any actualObject isKindOf: RGObject ]
+		ifFound: [ true ]
+		ifNone: [ false ]
+]
+
+{ #category : #activation }
 ClyExercismReviewSummaryCommand class >> rcmdShortcutActivation [
 	<classAnnotation>
 	


### PR DESCRIPTION
fixing the bad inheritance of menu items, cause this menu to break