### PR TITLE
Document exercism API

### DIFF
--- a/docs/exercism-api.md
+++ b/docs/exercism-api.md
@@ -10,12 +10,15 @@ All Endpoints require headers on the request to be set to the following values:
 
 ```
 Authorization: Bearer <token>
-Content-Type: application/json
 ```
 
 The value `<token>` is the users CLI authentication token available at `https://exercism.io/my/settings`.
 
 ## Fetching Exercises
+
+```
+Content-Type: application/json
+```
 
 `GET api.exercism.io/v1/solutions/latest?exercise_id=<name>&track_id<language> HTTP/1.1`
 
@@ -31,7 +34,7 @@ A sucessful request will respond with the exercise.
 
 #### 400
 
-The language track name is ambiguous.
+The language track name is ambiguous, or the submitted exercise files have not changed.
 
 #### 403
 
@@ -41,7 +44,33 @@ The solution not unlocked for the user or the language track is not joined.
 
 The language track or exercise could not be found.
 
-## References
+## Submitting Exercises
+
+```
+Content-Type: application/octet-stream
+```
+
+`PATCH api.exercism.io//v1/solutions/<some-kind-of-token-or-hash> HTTP/1.1`
+
+### Response
+
+#### 201
+
+A successful submission.
+
+#### 400
+
+A submitted file is too large (greater than one megabyte), or the solution is a duplicate.
+
+#### 403
+
+The solution is not accessable to the user. The solution user ID and the current user ID don't match.
+
+#### 404
+
+The solution ID was not found.
+
+## Reference
 
 - [exercism/pharo-smalltalk issue-32](https://github.com/exercism/pharo-smalltalk/issues/32)
 - [exercism/exercism issue-4087](https://github.com/exercism/exercism/issues/4087)

--- a/docs/exercism-api.md
+++ b/docs/exercism-api.md
@@ -28,9 +28,35 @@ In the URL above `<name>` is the name of the exercise e.g. `hello-world` and `<l
 
 #### 200
 
-A sucessful request will respond with the exercise.
+A sucessful request will send a response containing a JSON payload. Inside the JSON will be information on the exercise and a url from which to download the exercise files.
 
-`TODO` show response contents
+```json
+"solution":{
+	"id":"<id-string>",
+	"url":"https://exercism.io/my/solutions/<id-string>",
+	"team":null,
+	"user":{
+		"handle":"<exercism-user-name>",
+		"is_requester":true
+		},
+		"exercise":{
+			"id":"isogram",
+			"instructions_url":"https://exercism.io/my/solutions/<id-string>",
+			"auto_approve":false,
+			"track":{
+				"id":"pharo-smalltalk",
+				"language":"Pharo"
+				}
+			},
+			"file_download_base_url":"https://api.exercism.io/v1/solutions/<id-string>/files/",
+			"files":[
+				"IsogramTest.class.st",
+				"README.md"
+				],
+			"iteration":null
+		}
+	}
+```
 
 #### 400
 

--- a/docs/exercism-api.md
+++ b/docs/exercism-api.md
@@ -1,0 +1,49 @@
+# Exercism API
+
+## Description
+
+Most Exercism language tracks use the `exercism` command line tool for fetching and submitting exercises which interacts with `exercism.io` via a REST API. The Pharo Smalltalk language track instead uses the same REST API to bring exercises in and out of the Pharo image without the use of any intermediary tooling. This document details the Exercism API with a focus on how it is used by the Pharo Smalltalk language track. It is intended for maintainers of the Pharo Smalltalk tooling.
+
+## Headers
+
+All Endpoints require headers on the request to be set to the following values:
+
+```
+Authorization: Bearer <token>
+Content-Type: application/json
+```
+
+The value `<token>` is the users CLI authentication token available at `https://exercism.io/my/settings`.
+
+## Fetching Exercises
+
+`GET api.exercism.io/v1/solutions/latest?exercise_id=<name>&track_id<language> HTTP/1.1`
+
+In the URL above `<name>` is the name of the exercise e.g. `hello-world` and `<language>` is the language track e.g. `pharo-smalltalk`.
+
+### Response
+
+#### 200
+
+A sucessful request will respond with the exercise.
+
+`TODO` show response contents
+
+#### 400
+
+The language track name is ambiguous.
+
+#### 403
+
+The solution not unlocked for the user or the language track is not joined.
+
+#### 404
+
+The language track or exercise could not be found.
+
+## References
+
+- [exercism/pharo-smalltalk issue-32](https://github.com/exercism/pharo-smalltalk/issues/32)
+- [exercism/exercism issue-4087](https://github.com/exercism/exercism/issues/4087)
+- Refer to download and submit tests
+


### PR DESCRIPTION
Fixes #281.

This is work in progress for the moment. 

I've started with fetching exercises for now. Documenting the details of a `200` response is a bit difficult for me. I'm not that familiar with REST APIs and trying to get an idea of what it would look like from reading our own code is hard too.

Checking the exercism website source code has been very useful for getting the range of possible responses.

More to follow in this PR. The details of a `200` response need to be written and submitting exercises needs to be documented.