### PR TITLE
[Allergies] Use plain Error

### DIFF
--- a/dev/src/Exercise@Allergies/Allergies.class.st
+++ b/dev/src/Exercise@Allergies/Allergies.class.st
@@ -32,5 +32,5 @@ Allergies >> allergyListForScore: scoringInteger [
 Allergies >> bitIndexFor: aString [
 	^ self class allergyList
 		indexOf: aString
-		ifAbsent: [ ^ DomainError signal: 'invalid food item, ' , aString ]
+		ifAbsent: [ ^ Error signal: 'invalid food item, ' , aString ]
 ]


### PR DESCRIPTION
I'd like to use more specific  ApplicationError, but "domain" seems strongly tied to mathematics from than application when the class description is considered...
```
I am DomainError, an ArithmeticException indicating that some argument 
falls outside an expected domain, [from, to] When my valid interval is left- or right-open, 
use signal: creation protocol to provide a custom messageText rather than the default [from, to] notation.
```