### PR TITLE
Add alternative solution to TwelveDays exercise

### DIFF
--- a/dev/src/Exercise@TwelveDays/TwelveDays2.class.st
+++ b/dev/src/Exercise@TwelveDays/TwelveDays2.class.st
@@ -1,0 +1,47 @@
+"
+Mentor notes:
+
+- this alternate solution demonstrates use of `SequenceableCollection>>#joinUsing:last:`, connecting a series of strings with a common separator while changing the separator for the last string.
+"
+Class {
+	#name : #TwelveDays2,
+	#superclass : #Object,
+	#category : #'Exercise@TwelveDays-Solution2'
+}
+
+{ #category : #converting }
+TwelveDays2 >> dayName: anInteger [
+	"This would ideally be an extension on Integer or something on those lines"
+	^ #(first second third fourth fifth sixth seventh eighth ninth tenth eleventh twelfth) at: anInteger
+]
+
+{ #category : #reciting }
+TwelveDays2 >> getVerse: anInteger [ 
+	| elements |
+	elements := (self verses first: anInteger) reverse.
+	^ 'On the ' , (self dayName: anInteger)
+		, ' day of Christmas my true love gave to me: '
+		, (elements joinUsing: ', ' last: ', and ') , '.'
+]
+
+{ #category : #reciting }
+TwelveDays2 >> reciteStartVerse: start endVerse: end [
+	^ (start to: end) collect: [ :each | self getVerse: each ]
+]
+
+{ #category : #reciting }
+TwelveDays2 >> verses [
+	^ #(
+	'a Partridge in a Pear Tree'
+	'two Turtle Doves'
+	'three French Hens'
+	'four Calling Birds'
+	'five Gold Rings'
+	'six Geese-a-Laying' 
+	'seven Swans-a-Swimming' 
+	'eight Maids-a-Milking' 
+	'nine Ladies Dancing'
+	'ten Lords-a-Leaping' 
+	'eleven Pipers Piping' 
+	'twelve Drummers Drumming' )
+]

--- a/dev/src/Exercise@TwelveDays/TwelveDays2Test.class.st
+++ b/dev/src/Exercise@TwelveDays/TwelveDays2Test.class.st
@@ -3,3 +3,9 @@ Class {
 	#superclass : #TwelveDaysTest,
 	#category : #'Exercise@TwelveDays-Solution2'
 }
+
+{ #category : #running }
+TwelveDays2Test >> setUp [
+	super setUp.
+	twelveDaysCalculator := TwelveDays2 new
+]

--- a/dev/src/Exercise@TwelveDays/TwelveDays2Test.class.st
+++ b/dev/src/Exercise@TwelveDays/TwelveDays2Test.class.st
@@ -1,0 +1,5 @@
+Class {
+	#name : #TwelveDays2Test,
+	#superclass : #TwelveDaysTest,
+	#category : #'Exercise@TwelveDays-Solution2'
+}

--- a/dev/src/Exercise@TwelveDays/TwelveDaysTest.class.st
+++ b/dev/src/Exercise@TwelveDays/TwelveDaysTest.class.st
@@ -86,7 +86,7 @@ TwelveDaysTest class >> version [
 { #category : #running }
 TwelveDaysTest >> setUp [
 	super setUp.
-	twelveDaysCalculator := TwelveDays2 new
+	twelveDaysCalculator := TwelveDays new
 ]
 
 { #category : #tests }

--- a/dev/src/Exercise@TwelveDays/TwelveDaysTest.class.st
+++ b/dev/src/Exercise@TwelveDays/TwelveDaysTest.class.st
@@ -86,7 +86,7 @@ TwelveDaysTest class >> version [
 { #category : #running }
 TwelveDaysTest >> setUp [
 	super setUp.
-	twelveDaysCalculator := TwelveDays new
+	twelveDaysCalculator := TwelveDays2 new
 ]
 
 { #category : #tests }


### PR DESCRIPTION
Here is how an alternative solution to Twelve Days might look based on the solution shown in #386. The biggest change is that `#verse:` is swapped out for `#getVerse:` (might keep the name the same if we use this solution). `#verses` and `#dayName` are direct copies of the first solutions `#gifts` and `#ordinal:` respectively, the names just changed to fit in with the alternate solution. 

The big point of this solution is that it uses `SequencableCollection#>>joinUsing:last:` in `#getVerse`.

Let me know if you want to go ahead with this.