### PR TITLE
Document ExercismTools Menu classes

### DIFF
--- a/dev/src/ExercismTools/ClyExercismCommand.class.st
+++ b/dev/src/ExercismTools/ClyExercismCommand.class.st
@@ -1,5 +1,25 @@
 "
-Abstract class to provide menu facilties for Exercism that should only appear in the context of the Exercism package (and not other browser packages)
+# ClyExercismCommand
+
+I provide menu facilities for Exercism that should only appear in the 
+context of an Exercism package (and not in other browser packages).
+
+I am an abstract class.
+
+## Design
+
+I follow the Command Pattern of Object Oriented Design. I do one task 
+on recieving the `#execute` message, which must be implemented by 
+subclasses. All other methods should be about setting up the state
+requred for the `#execute` method to carry out its task.
+
+The `#execute` method is written further up the inheritance hierarchy
+at `CmdCommand>>#execute`.
+
+## Instance Variables
+
+- browser: ClyPackageContextOfFullBrowser, the context of of a browser instance containing packages.
+- selectedItem: RPackage, the selected package in the browser context.
 "
 Class {
 	#name : #ClyExercismCommand,
@@ -39,10 +59,10 @@ ClyExercismCommand >> browser: anObject [
 	browser := anObject
 ]
 
-{ #category : #accessing }
+{ #category : #execution }
 ClyExercismCommand >> prepareFullExecutionInContext: aToolContext [
 	super prepareFullExecutionInContext: aToolContext.
-	
+
 	self selectedItem: (self selectedItemIn: aToolContext).
 	self browser: aToolContext tool
 ]

--- a/dev/src/ExercismTools/ClyExercismExerciseCommand.class.st
+++ b/dev/src/ExercismTools/ClyExercismExerciseCommand.class.st
@@ -1,5 +1,27 @@
 "
-Exercism menu items that should only appear on a package tag 
+# ClyExercismExerciseCommand
+
+I am the Abstract super class of all Exercism exercise menu commands.
+Menu items subclassing me should only appear on exercise package tags
+in the browser.
+
+## GUI Menu 
+
+Subclasses of me are grouped into a browser menu under the name 
+""Exercism"" when activating a menu on a package or tag. This submenu
+is created by the class methods `#packageContextMenuActivation` and
+`#tagContextMenuActivation`.
+
+## Error reporting
+
+Subclasess may use `#reportError:for:` to report errors. 
+
+In one error case the exercise may be missing metadata and will need 
+to be upgraded in the users Exercism profile and re-fetched.
+
+In another error case the exercise may not be found. The likely 
+problem is that the exercise name is misspelled or does not exist in
+the Pharo-Smalltalk language track. 
 "
 Class {
 	#name : #ClyExercismExerciseCommand,

--- a/dev/src/ExercismTools/ClyExercismFetchCommand.class.st
+++ b/dev/src/ExercismTools/ClyExercismFetchCommand.class.st
@@ -1,5 +1,29 @@
 "
-Menu command to fetch a new exercise
+# ClyExercismFetchCommand
+
+I am a browser menu item command that initiates a fetch operation to 
+get a specific exercise from Exercism.io.
+
+## Command Execution
+
+I implement the `#execute` method. On receiving this message I start 
+the fetch operation to get an exercise, and report the success or error
+of the operation via the UI.
+
+I send a message to `ExercismManager default` to fetch the exercise.
+On successful retrieval of an exercise I will open a browser window on
+that exercises test case.
+
+I may signal an `ExDomainError` if I could not retrieve an exercise from
+the `ExercismManager` submission.
+
+If the `ExercismManager` signals an `ExDomainError` I will report the
+error with `ClyExercismExerciseCommand>>#reportError:for:`.
+
+## World Menu
+
+On my class side is `#worldMenuCommandOn:`. This method adds a ""Fetch
+new exercise..."" command to the World menu under the ""Exercism"" section.
 "
 Class {
 	#name : #ClyExercismFetchCommand,

--- a/dev/src/ExercismTools/ClyExercismMenuGroup.class.st
+++ b/dev/src/ExercismTools/ClyExercismMenuGroup.class.st
@@ -1,5 +1,13 @@
 "
-The Exercism menu group
+# ClyExercismMenuGroup
+
+I am the group of Exercism menu item commands. My class can be used to
+group Exercism specific menu items.
+
+I am used in `ClyExercismExerciseCommand class>>#packageContextMenuActivation`
+and `ClyExercismExerciseCommand class >>#tagContextMenuActivation`.
+
+ 
 "
 Class {
 	#name : #ClyExercismMenuGroup,

--- a/dev/src/ExercismTools/ClyExercismProgressCommand.class.st
+++ b/dev/src/ExercismTools/ClyExercismProgressCommand.class.st
@@ -1,5 +1,18 @@
 "
-Menu command to view progress on the exercism website
+# ClyExercisProgressCommand
+
+I am a browser menu item command that initiates an operation to view
+the users progress of an exercise on the Exercism website.
+
+## Command Execution
+
+In my `#execute` method I send a message to `ExercismManager default`
+to view the selected exercise in the browser on the Exercism website.
+
+## World Menu
+
+On my class side `#worldMenuCommandOn:` creates an entry labeled ""View
+Track Progress"" for me in the World menu under the ""Exercism"" section.
 "
 Class {
 	#name : #ClyExercismProgressCommand,

--- a/dev/src/ExercismTools/ClyExercismShareCommand.class.st
+++ b/dev/src/ExercismTools/ClyExercismShareCommand.class.st
@@ -1,3 +1,28 @@
+"
+# ClyExercismShareCommand
+
+I am a browser menu item command. I can be used to share the code of 
+an exercise solution by creating an anonymous web link to `dpaste.com`.
+
+## Enabling Sharing
+
+Sharing will not be possible unless the class method 
+`#hasComfirmedSharing:` is used to set the class variable of the same 
+name to `true`.
+
+## Command Execution
+
+In my `#execute` method I initiate and handle the result of the 
+sharing operation. I send a message to `ExercismManager default` to
+start the sharing.
+
+I may report an `ExercismError` signaled my `ExercismManager` using
+`ClyExercismExerciseCommand>>#reportError:for:`. I may use the same
+message to report an error if the exercise name can't be found.
+
+On a successful operation I will copy the dpase.com URL to the
+clipboard and open the webbrowser on the URL.
+"
 Class {
 	#name : #ClyExercismShareCommand,
 	#superclass : #ClyExercismExerciseCommand,

--- a/dev/src/ExercismTools/ClyExercismSubmitCommand.class.st
+++ b/dev/src/ExercismTools/ClyExercismSubmitCommand.class.st
@@ -1,5 +1,18 @@
 "
-Menu command to submit a new exercise
+# ClyExercismSubmitCommand
+
+I am a browser menu item command. I initiate submitting the selected
+exercise solution to the Exercism website.
+
+## Command Execution
+
+On recieving the message `#execute` I initiate the submit operation by
+sending the message `#submitToExercism:` to `ExercismManager default`.
+This will submit my selected exercise.
+
+If an `ExercismError` is signaled I will report the error with
+`#reportError:for:`. 
+
 "
 Class {
 	#name : #ClyExercismSubmitCommand,


### PR DESCRIPTION
Fixes #397.

Here I have expanded the documentation on the class comments across the package. This is something to help my own understanding of the code base and to help anyone else who may be unfamiliar too.

I've used Markdown format for the comments. Also I shifted `ClyExercismCommand>>#prepareFullExecutionInContext:` into the `execution` protocol/category to match the super class.

Let me know if you think there is anything I can add here or if anything needs changing.

Also I understand that all of us may be too busy at times with life outside of Github to review each pull request or issue. If it is OK with you I think it is a good idea to allow maintainers to merge pull requests and close issues with no further review from others if no one else has the time available. That way we can keep some progress going instead of having pull requests in semi-limbo. Tell me what you think.
