### PR TITLE
Update broken Discord invite link

### DIFF
--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -12,7 +12,7 @@ it fits on a postcard
 a full pdf book with step by step examples
 * [Learning OOP and TDD in Pharo](http://books.pharo.org/learning-oop/):
 introduces more programming techniques and concepts
-* [Discord](https://discordapp.com/invite/Sj2rhxn) has an
+* [Discord](https://discord.gg/QewZMZa) has an
 active online Pharo discussions forum (use the invite link at the top of the [Community Page](http://pharo.org/community))
 * [Pharo Mooc](http://mooc.pharo.org/):
 provides a series of full programming courses and videos


### PR DESCRIPTION
The link is updated to the same as that on the http://pharo.org/community page.