### PR TITLE
Fix broken fetch-configlet script

### DIFF
--- a/bin/fetch-configlet
+++ b/bin/fetch-configlet
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 LATEST=https://github.com/exercism/configlet/releases/latest
 
 OS=$(
@@ -26,7 +28,12 @@ case $(uname -m) in
         echo 64bit;;
 esac)
 
-VERSION="$(curl --head --silent $LATEST | awk -v FS=/ '/Location:/{print $NF}' | tr -d '\r')"
+VERSION="$(curl --head --silent $LATEST | awk -v FS=/ '/[lL]ocation:/{print $NF}' | tr -d '\r')"
+if [ -z "$VERSION" ]; then
+    echo "Latest configlet release could not be determined; aborting"
+    exit 1
+fi
+
 URL=https://github.com/exercism/configlet/releases/download/$VERSION/configlet-$OS-${ARCH}.tgz
 
-curl -s --location $URL | tar xz -C bin/
+curl -sS --location $URL | tar xz -C bin/


### PR DESCRIPTION
This seems to be a problem across many [tracks](https://github.com/exercism/configlet/issues/173). The changes here are based of those in the [Rust track](https://github.com/exercism/rust/pull/929/files). I've chosen that particular one because I can understand what the changes do.

The [original source](https://github.com/exercism/configlet/blob/master/scripts/fetch-configlet) `fetch-configlet` script has a lot of differences that are currently beyond my understanding.