### PR TITLE
Create ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [master]
+  pull_request:
 
 jobs:
   lint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,6 @@ jobs:
         
   tree:
     runs-on: ubuntu-latest
-        runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v2
       
       - name: Fetch smalltalkCI
-        uses: hpi-swa/setup-smalltalkCI@v1
+        uses: hpi-swa/setup-smalltalkCI@a271ee530f18ecf947856f3f163c4687101ec6b6
         id: smalltalkci
         with: 
           smalltalk-version: 'Pharo64-8.0'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,6 @@ on: [push, pull_request]
 jobs:
   lint:
     runs-on: ubuntu-latest
-        runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+        runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Fetch configlet
+        uses: exercism/github-actions/configlet-ci@master
+
+      - name: Configlet Linter
+        run: configlet lint --track-id pharo .
+    
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      
+      - name: Fetch smalltalkCI
+        uses: hpi-swa/setup-smalltalkCI@v1
+        id: smalltalkci
+        with: 
+          smalltalk-version: 'Pharo64-8.0'
+      - run: smalltalkci -s ${{ steps.smalltalkci.outputs.smalltalk-version }}
+        shell: bash
+        timeout-minutes: 15
+        
+  tree:
+    runs-on: ubuntu-latest
+        runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Fetch configlet
+        uses: exercism/github-actions/configlet-ci@master
+
+      - name: Configlet Tree
+        run: configlet tree --with-difficulty .


### PR DESCRIPTION
Fixes #425 

As with the rest of Exercism we are migrating CI from Travis to Github Actions.

For reviewer reference smalltalkCI is a tool specifically for running CI pipelines on Smalltalk dialects. We are using [their Github Action](https://github.com/marketplace/actions/setup-smalltalkci). It makes use of this [STON ](https://github.com/exercism/pharo-smalltalk/blob/master/.smalltalk.ston) (a Smalltalk JSON equivalent) file in our repo to decide which tests to run.

I've tried to map what our existing [Travis file](https://github.com/exercism/pharo-smalltalk/blob/master/.travis.yml) does to this workflow but I'm not an expert in either tool.