### PR TITLE
Create Exercism V3 baseline

### DIFF
--- a/dev/src/BaselineOfExercism/BaselineOfExercism.class.st
+++ b/dev/src/BaselineOfExercism/BaselineOfExercism.class.st
@@ -51,6 +51,8 @@ BaselineOfExercism >> baseline: spec [
 						'ExercismTools' ),  
 						self class exercisePackageNames ];
 			
+				package: 'ExercismV3';
+				
 				group: 'default'
 					with: #('ExercismTools' 'Exercise@Welcome');
 					
@@ -58,7 +60,10 @@ BaselineOfExercism >> baseline: spec [
 					with: #('ExercismDev' );
 				
 				group: 'dev'
-					with: #('ExercismDev' 'ExercismWIP' 'ExercismSystemTests')]
+					with: #('ExercismDev' 'ExercismWIP' 'ExercismSystemTests');
+				
+				group: 'v3'
+					with: #('ExercismV3')]
 ]
 
 { #category : #baselines }

--- a/dev/src/ExercismV3/SourceImporter.class.st
+++ b/dev/src/ExercismV3/SourceImporter.class.st
@@ -1,0 +1,5 @@
+Class {
+	#name : #SourceImporter,
+	#superclass : #Object,
+	#category : #ExercismV3
+}

--- a/dev/src/ExercismV3/package.st
+++ b/dev/src/ExercismV3/package.st
@@ -1,0 +1,1 @@
+Package { #name : #ExercismV3 }


### PR DESCRIPTION
The intention is to create the code supporting Exercism version 3 (V3) from a clean start. Refactoring
V2 code has proven too large a task.

With a V3 baseline we can load the code and dependencies into the image without any V2 code cluttering
things up. This also allows us to keep development of both versions in the same repository.

`SourceImporter` is just a class stub so that the baseline contains something and we can verify that it
loads correctly.

The V3 baseline can be loaded using Iceberg:  In the repositories window, right click on the 
`pharo-smalltalk` repository -> mouse over `Metacello` -> left click on `Install baseline of Exercism...`
-> enter `v3` into the text field -> left click the `OK` button.