### PR TITLE
🤖 Update tests.toml files to latest spec

### DIFF
--- a/exercises/practice/acronym/.meta/tests.toml
+++ b/exercises/practice/acronym/.meta/tests.toml
@@ -1,28 +1,30 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# basic
-"1e22cceb-c5e4-4562-9afe-aef07ad1eaf4" = true
+[1e22cceb-c5e4-4562-9afe-aef07ad1eaf4]
+description = "basic"
 
-# lowercase words
-"79ae3889-a5c0-4b01-baf0-232d31180c08" = true
+[79ae3889-a5c0-4b01-baf0-232d31180c08]
+description = "lowercase words"
 
-# punctuation
-"ec7000a7-3931-4a17-890e-33ca2073a548" = true
+[ec7000a7-3931-4a17-890e-33ca2073a548]
+description = "punctuation"
 
-# all caps word
-"32dd261c-0c92-469a-9c5c-b192e94a63b0" = true
+[32dd261c-0c92-469a-9c5c-b192e94a63b0]
+description = "all caps word"
 
-# punctuation without whitespace
-"ae2ac9fa-a606-4d05-8244-3bcc4659c1d4" = true
+[ae2ac9fa-a606-4d05-8244-3bcc4659c1d4]
+description = "punctuation without whitespace"
 
-# very long abbreviation
-"0e4b1e7c-1a6d-48fb-81a7-bf65eb9e69f9" = true
+[0e4b1e7c-1a6d-48fb-81a7-bf65eb9e69f9]
+description = "very long abbreviation"
 
-# consecutive delimiters
-"6a078f49-c68d-4b7b-89af-33a1a98c28cc" = true
+[6a078f49-c68d-4b7b-89af-33a1a98c28cc]
+description = "consecutive delimiters"
 
-# apostrophes
-"5118b4b1-4572-434c-8d57-5b762e57973e" = true
+[5118b4b1-4572-434c-8d57-5b762e57973e]
+description = "apostrophes"
 
-# underscore emphasis
-"adc12eab-ec2d-414f-b48c-66a4fc06cdef" = true
+[adc12eab-ec2d-414f-b48c-66a4fc06cdef]
+description = "underscore emphasis"

--- a/exercises/practice/allergies/.meta/tests.toml
+++ b/exercises/practice/allergies/.meta/tests.toml
@@ -1,148 +1,150 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# not allergic to anything
-"17fc7296-2440-4ac4-ad7b-d07c321bc5a0" = true
+[17fc7296-2440-4ac4-ad7b-d07c321bc5a0]
+description = "not allergic to anything"
 
-# allergic only to eggs
-"07ced27b-1da5-4c2e-8ae2-cb2791437546" = true
+[07ced27b-1da5-4c2e-8ae2-cb2791437546]
+description = "allergic only to eggs"
 
-# allergic to eggs and something else
-"5035b954-b6fa-4b9b-a487-dae69d8c5f96" = true
+[5035b954-b6fa-4b9b-a487-dae69d8c5f96]
+description = "allergic to eggs and something else"
 
-# allergic to something, but not eggs
-"64a6a83a-5723-4b5b-a896-663307403310" = true
+[64a6a83a-5723-4b5b-a896-663307403310]
+description = "allergic to something, but not eggs"
 
-# allergic to everything
-"90c8f484-456b-41c4-82ba-2d08d93231c6" = true
+[90c8f484-456b-41c4-82ba-2d08d93231c6]
+description = "allergic to everything"
 
-# not allergic to anything
-"d266a59a-fccc-413b-ac53-d57cb1f0db9d" = true
+[d266a59a-fccc-413b-ac53-d57cb1f0db9d]
+description = "not allergic to anything"
 
-# allergic only to peanuts
-"ea210a98-860d-46b2-a5bf-50d8995b3f2a" = true
+[ea210a98-860d-46b2-a5bf-50d8995b3f2a]
+description = "allergic only to peanuts"
 
-# allergic to peanuts and something else
-"eac69ae9-8d14-4291-ac4b-7fd2c73d3a5b" = true
+[eac69ae9-8d14-4291-ac4b-7fd2c73d3a5b]
+description = "allergic to peanuts and something else"
 
-# allergic to something, but not peanuts
-"9152058c-ce39-4b16-9b1d-283ec6d25085" = true
+[9152058c-ce39-4b16-9b1d-283ec6d25085]
+description = "allergic to something, but not peanuts"
 
-# allergic to everything
-"d2d71fd8-63d5-40f9-a627-fbdaf88caeab" = true
+[d2d71fd8-63d5-40f9-a627-fbdaf88caeab]
+description = "allergic to everything"
 
-# not allergic to anything
-"b948b0a1-cbf7-4b28-a244-73ff56687c80" = true
+[b948b0a1-cbf7-4b28-a244-73ff56687c80]
+description = "not allergic to anything"
 
-# allergic only to shellfish
-"9ce9a6f3-53e9-4923-85e0-73019047c567" = true
+[9ce9a6f3-53e9-4923-85e0-73019047c567]
+description = "allergic only to shellfish"
 
-# allergic to shellfish and something else
-"b272fca5-57ba-4b00-bd0c-43a737ab2131" = true
+[b272fca5-57ba-4b00-bd0c-43a737ab2131]
+description = "allergic to shellfish and something else"
 
-# allergic to something, but not shellfish
-"21ef8e17-c227-494e-8e78-470a1c59c3d8" = true
+[21ef8e17-c227-494e-8e78-470a1c59c3d8]
+description = "allergic to something, but not shellfish"
 
-# allergic to everything
-"cc789c19-2b5e-4c67-b146-625dc8cfa34e" = true
+[cc789c19-2b5e-4c67-b146-625dc8cfa34e]
+description = "allergic to everything"
 
-# not allergic to anything
-"651bde0a-2a74-46c4-ab55-02a0906ca2f5" = true
+[651bde0a-2a74-46c4-ab55-02a0906ca2f5]
+description = "not allergic to anything"
 
-# allergic only to strawberries
-"b649a750-9703-4f5f-b7f7-91da2c160ece" = true
+[b649a750-9703-4f5f-b7f7-91da2c160ece]
+description = "allergic only to strawberries"
 
-# allergic to strawberries and something else
-"50f5f8f3-3bac-47e6-8dba-2d94470a4bc6" = true
+[50f5f8f3-3bac-47e6-8dba-2d94470a4bc6]
+description = "allergic to strawberries and something else"
 
-# allergic to something, but not strawberries
-"23dd6952-88c9-48d7-a7d5-5d0343deb18d" = true
+[23dd6952-88c9-48d7-a7d5-5d0343deb18d]
+description = "allergic to something, but not strawberries"
 
-# allergic to everything
-"74afaae2-13b6-43a2-837a-286cd42e7d7e" = true
+[74afaae2-13b6-43a2-837a-286cd42e7d7e]
+description = "allergic to everything"
 
-# not allergic to anything
-"c49a91ef-6252-415e-907e-a9d26ef61723" = true
+[c49a91ef-6252-415e-907e-a9d26ef61723]
+description = "not allergic to anything"
 
-# allergic only to tomatoes
-"b69c5131-b7d0-41ad-a32c-e1b2cc632df8" = true
+[b69c5131-b7d0-41ad-a32c-e1b2cc632df8]
+description = "allergic only to tomatoes"
 
-# allergic to tomatoes and something else
-"1ca50eb1-f042-4ccf-9050-341521b929ec" = true
+[1ca50eb1-f042-4ccf-9050-341521b929ec]
+description = "allergic to tomatoes and something else"
 
-# allergic to something, but not tomatoes
-"e9846baa-456b-4eff-8025-034b9f77bd8e" = true
+[e9846baa-456b-4eff-8025-034b9f77bd8e]
+description = "allergic to something, but not tomatoes"
 
-# allergic to everything
-"b2414f01-f3ad-4965-8391-e65f54dad35f" = true
+[b2414f01-f3ad-4965-8391-e65f54dad35f]
+description = "allergic to everything"
 
-# not allergic to anything
-"978467ab-bda4-49f7-b004-1d011ead947c" = true
+[978467ab-bda4-49f7-b004-1d011ead947c]
+description = "not allergic to anything"
 
-# allergic only to chocolate
-"59cf4e49-06ea-4139-a2c1-d7aad28f8cbc" = true
+[59cf4e49-06ea-4139-a2c1-d7aad28f8cbc]
+description = "allergic only to chocolate"
 
-# allergic to chocolate and something else
-"b0a7c07b-2db7-4f73-a180-565e07040ef1" = true
+[b0a7c07b-2db7-4f73-a180-565e07040ef1]
+description = "allergic to chocolate and something else"
 
-# allergic to something, but not chocolate
-"f5506893-f1ae-482a-b516-7532ba5ca9d2" = true
+[f5506893-f1ae-482a-b516-7532ba5ca9d2]
+description = "allergic to something, but not chocolate"
 
-# allergic to everything
-"02debb3d-d7e2-4376-a26b-3c974b6595c6" = true
+[02debb3d-d7e2-4376-a26b-3c974b6595c6]
+description = "allergic to everything"
 
-# not allergic to anything
-"17f4a42b-c91e-41b8-8a76-4797886c2d96" = true
+[17f4a42b-c91e-41b8-8a76-4797886c2d96]
+description = "not allergic to anything"
 
-# allergic only to pollen
-"7696eba7-1837-4488-882a-14b7b4e3e399" = true
+[7696eba7-1837-4488-882a-14b7b4e3e399]
+description = "allergic only to pollen"
 
-# allergic to pollen and something else
-"9a49aec5-fa1f-405d-889e-4dfc420db2b6" = true
+[9a49aec5-fa1f-405d-889e-4dfc420db2b6]
+description = "allergic to pollen and something else"
 
-# allergic to something, but not pollen
-"3cb8e79f-d108-4712-b620-aa146b1954a9" = true
+[3cb8e79f-d108-4712-b620-aa146b1954a9]
+description = "allergic to something, but not pollen"
 
-# allergic to everything
-"1dc3fe57-7c68-4043-9d51-5457128744b2" = true
+[1dc3fe57-7c68-4043-9d51-5457128744b2]
+description = "allergic to everything"
 
-# not allergic to anything
-"d3f523d6-3d50-419b-a222-d4dfd62ce314" = true
+[d3f523d6-3d50-419b-a222-d4dfd62ce314]
+description = "not allergic to anything"
 
-# allergic only to cats
-"eba541c3-c886-42d3-baef-c048cb7fcd8f" = true
+[eba541c3-c886-42d3-baef-c048cb7fcd8f]
+description = "allergic only to cats"
 
-# allergic to cats and something else
-"ba718376-26e0-40b7-bbbe-060287637ea5" = true
+[ba718376-26e0-40b7-bbbe-060287637ea5]
+description = "allergic to cats and something else"
 
-# allergic to something, but not cats
-"3c6dbf4a-5277-436f-8b88-15a206f2d6c4" = true
+[3c6dbf4a-5277-436f-8b88-15a206f2d6c4]
+description = "allergic to something, but not cats"
 
-# allergic to everything
-"1faabb05-2b98-4995-9046-d83e4a48a7c1" = true
+[1faabb05-2b98-4995-9046-d83e4a48a7c1]
+description = "allergic to everything"
 
-# no allergies
-"f9c1b8e7-7dc5-4887-aa93-cebdcc29dd8f" = true
+[f9c1b8e7-7dc5-4887-aa93-cebdcc29dd8f]
+description = "no allergies"
 
-# just eggs
-"9e1a4364-09a6-4d94-990f-541a94a4c1e8" = true
+[9e1a4364-09a6-4d94-990f-541a94a4c1e8]
+description = "just eggs"
 
-# just peanuts
-"8851c973-805e-4283-9e01-d0c0da0e4695" = true
+[8851c973-805e-4283-9e01-d0c0da0e4695]
+description = "just peanuts"
 
-# just strawberries
-"2c8943cb-005e-435f-ae11-3e8fb558ea98" = true
+[2c8943cb-005e-435f-ae11-3e8fb558ea98]
+description = "just strawberries"
 
-# eggs and peanuts
-"6fa95d26-044c-48a9-8a7b-9ee46ec32c5c" = true
+[6fa95d26-044c-48a9-8a7b-9ee46ec32c5c]
+description = "eggs and peanuts"
 
-# more than eggs but not peanuts
-"19890e22-f63f-4c5c-a9fb-fb6eacddfe8e" = true
+[19890e22-f63f-4c5c-a9fb-fb6eacddfe8e]
+description = "more than eggs but not peanuts"
 
-# lots of stuff
-"4b68f470-067c-44e4-889f-c9fe28917d2f" = true
+[4b68f470-067c-44e4-889f-c9fe28917d2f]
+description = "lots of stuff"
 
-# everything
-"0881b7c5-9efa-4530-91bd-68370d054bc7" = true
+[0881b7c5-9efa-4530-91bd-68370d054bc7]
+description = "everything"
 
-# no allergen score parts
-"12ce86de-b347-42a0-ab7c-2e0570f0c65b" = true
+[12ce86de-b347-42a0-ab7c-2e0570f0c65b]
+description = "no allergen score parts"

--- a/exercises/practice/anagram/.meta/tests.toml
+++ b/exercises/practice/anagram/.meta/tests.toml
@@ -1,43 +1,45 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# no matches
-"dd40c4d2-3c8b-44e5-992a-f42b393ec373" = true
+[dd40c4d2-3c8b-44e5-992a-f42b393ec373]
+description = "no matches"
 
-# detects two anagrams
-"b3cca662-f50a-489e-ae10-ab8290a09bdc" = true
+[b3cca662-f50a-489e-ae10-ab8290a09bdc]
+description = "detects two anagrams"
 
-# does not detect anagram subsets
-"a27558ee-9ba0-4552-96b1-ecf665b06556" = true
+[a27558ee-9ba0-4552-96b1-ecf665b06556]
+description = "does not detect anagram subsets"
 
-# detects anagram
-"64cd4584-fc15-4781-b633-3d814c4941a4" = true
+[64cd4584-fc15-4781-b633-3d814c4941a4]
+description = "detects anagram"
 
-# detects three anagrams
-"99c91beb-838f-4ccd-b123-935139917283" = true
+[99c91beb-838f-4ccd-b123-935139917283]
+description = "detects three anagrams"
 
-# detects multiple anagrams with different case
-"78487770-e258-4e1f-a646-8ece10950d90" = true
+[78487770-e258-4e1f-a646-8ece10950d90]
+description = "detects multiple anagrams with different case"
 
-# does not detect non-anagrams with identical checksum
-"1d0ab8aa-362f-49b7-9902-3d0c668d557b" = true
+[1d0ab8aa-362f-49b7-9902-3d0c668d557b]
+description = "does not detect non-anagrams with identical checksum"
 
-# detects anagrams case-insensitively
-"9e632c0b-c0b1-4804-8cc1-e295dea6d8a8" = true
+[9e632c0b-c0b1-4804-8cc1-e295dea6d8a8]
+description = "detects anagrams case-insensitively"
 
-# detects anagrams using case-insensitive subject
-"b248e49f-0905-48d2-9c8d-bd02d8c3e392" = true
+[b248e49f-0905-48d2-9c8d-bd02d8c3e392]
+description = "detects anagrams using case-insensitive subject"
 
-# detects anagrams using case-insensitive possible matches
-"f367325c-78ec-411c-be76-e79047f4bd54" = true
+[f367325c-78ec-411c-be76-e79047f4bd54]
+description = "detects anagrams using case-insensitive possible matches"
 
-# does not detect an anagram if the original word is repeated
-"7cc195ad-e3c7-44ee-9fd2-d3c344806a2c" = true
+[7cc195ad-e3c7-44ee-9fd2-d3c344806a2c]
+description = "does not detect an anagram if the original word is repeated"
 
-# anagrams must use all letters exactly once
-"9878a1c9-d6ea-4235-ae51-3ea2befd6842" = true
+[9878a1c9-d6ea-4235-ae51-3ea2befd6842]
+description = "anagrams must use all letters exactly once"
 
-# words are not anagrams of themselves (case-insensitive)
-"85757361-4535-45fd-ac0e-3810d40debc1" = true
+[85757361-4535-45fd-ac0e-3810d40debc1]
+description = "words are not anagrams of themselves (case-insensitive)"
 
-# words other than themselves can be anagrams
-"a0705568-628c-4b55-9798-82e4acde51ca" = true
+[a0705568-628c-4b55-9798-82e4acde51ca]
+description = "words other than themselves can be anagrams"

--- a/exercises/practice/armstrong-numbers/.meta/tests.toml
+++ b/exercises/practice/armstrong-numbers/.meta/tests.toml
@@ -1,28 +1,30 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# Zero is an Armstrong number
-"c1ed103c-258d-45b2-be73-d8c6d9580c7b" = true
+[c1ed103c-258d-45b2-be73-d8c6d9580c7b]
+description = "Zero is an Armstrong number"
 
-# Single digit numbers are Armstrong numbers
-"579e8f03-9659-4b85-a1a2-d64350f6b17a" = true
+[579e8f03-9659-4b85-a1a2-d64350f6b17a]
+description = "Single digit numbers are Armstrong numbers"
 
-# There are no 2 digit Armstrong numbers
-"2d6db9dc-5bf8-4976-a90b-b2c2b9feba60" = true
+[2d6db9dc-5bf8-4976-a90b-b2c2b9feba60]
+description = "There are no 2 digit Armstrong numbers"
 
-# Three digit number that is an Armstrong number
-"509c087f-e327-4113-a7d2-26a4e9d18283" = true
+[509c087f-e327-4113-a7d2-26a4e9d18283]
+description = "Three digit number that is an Armstrong number"
 
-# Three digit number that is not an Armstrong number
-"7154547d-c2ce-468d-b214-4cb953b870cf" = true
+[7154547d-c2ce-468d-b214-4cb953b870cf]
+description = "Three digit number that is not an Armstrong number"
 
-# Four digit number that is an Armstrong number
-"6bac5b7b-42e9-4ecb-a8b0-4832229aa103" = true
+[6bac5b7b-42e9-4ecb-a8b0-4832229aa103]
+description = "Four digit number that is an Armstrong number"
 
-# Four digit number that is not an Armstrong number
-"eed4b331-af80-45b5-a80b-19c9ea444b2e" = true
+[eed4b331-af80-45b5-a80b-19c9ea444b2e]
+description = "Four digit number that is not an Armstrong number"
 
-# Seven digit number that is an Armstrong number
-"f971ced7-8d68-4758-aea1-d4194900b864" = true
+[f971ced7-8d68-4758-aea1-d4194900b864]
+description = "Seven digit number that is an Armstrong number"
 
-# Seven digit number that is not an Armstrong number
-"7ee45d52-5d35-4fbd-b6f1-5c8cd8a67f18" = true
+[7ee45d52-5d35-4fbd-b6f1-5c8cd8a67f18]
+description = "Seven digit number that is not an Armstrong number"

--- a/exercises/practice/atbash-cipher/.meta/tests.toml
+++ b/exercises/practice/atbash-cipher/.meta/tests.toml
@@ -1,43 +1,45 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# encode yes
-"2f47ebe1-eab9-4d6b-b3c6-627562a31c77" = true
+[2f47ebe1-eab9-4d6b-b3c6-627562a31c77]
+description = "encode yes"
 
-# encode no
-"b4ffe781-ea81-4b74-b268-cc58ba21c739" = true
+[b4ffe781-ea81-4b74-b268-cc58ba21c739]
+description = "encode no"
 
-# encode OMG
-"10e48927-24ab-4c4d-9d3f-3067724ace00" = true
+[10e48927-24ab-4c4d-9d3f-3067724ace00]
+description = "encode OMG"
 
-# encode spaces
-"d59b8bc3-509a-4a9a-834c-6f501b98750b" = true
+[d59b8bc3-509a-4a9a-834c-6f501b98750b]
+description = "encode spaces"
 
-# encode mindblowingly
-"31d44b11-81b7-4a94-8b43-4af6a2449429" = true
+[31d44b11-81b7-4a94-8b43-4af6a2449429]
+description = "encode mindblowingly"
 
-# encode numbers
-"d503361a-1433-48c0-aae0-d41b5baa33ff" = true
+[d503361a-1433-48c0-aae0-d41b5baa33ff]
+description = "encode numbers"
 
-# encode deep thought
-"79c8a2d5-0772-42d4-b41b-531d0b5da926" = true
+[79c8a2d5-0772-42d4-b41b-531d0b5da926]
+description = "encode deep thought"
 
-# encode all the letters
-"9ca13d23-d32a-4967-a1fd-6100b8742bab" = true
+[9ca13d23-d32a-4967-a1fd-6100b8742bab]
+description = "encode all the letters"
 
-# decode exercism
-"bb50e087-7fdf-48e7-9223-284fe7e69851" = true
+[bb50e087-7fdf-48e7-9223-284fe7e69851]
+description = "decode exercism"
 
-# decode a sentence
-"ac021097-cd5d-4717-8907-b0814b9e292c" = true
+[ac021097-cd5d-4717-8907-b0814b9e292c]
+description = "decode a sentence"
 
-# decode numbers
-"18729de3-de74-49b8-b68c-025eaf77f851" = true
+[18729de3-de74-49b8-b68c-025eaf77f851]
+description = "decode numbers"
 
-# decode all the letters
-"0f30325f-f53b-415d-ad3e-a7a4f63de034" = true
+[0f30325f-f53b-415d-ad3e-a7a4f63de034]
+description = "decode all the letters"
 
-# decode with too many spaces
-"39640287-30c6-4c8c-9bac-9d613d1a5674" = true
+[39640287-30c6-4c8c-9bac-9d613d1a5674]
+description = "decode with too many spaces"
 
-# decode with no spaces
-"b34edf13-34c0-49b5-aa21-0768928000d5" = true
+[b34edf13-34c0-49b5-aa21-0768928000d5]
+description = "decode with no spaces"

--- a/exercises/practice/binary/.meta/tests.toml
+++ b/exercises/practice/binary/.meta/tests.toml
@@ -1,46 +1,48 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# binary 0 is decimal 0
-"567fc71e-1013-4915-9285-bca0648c0844" = true
+[567fc71e-1013-4915-9285-bca0648c0844]
+description = "binary 0 is decimal 0"
 
-# binary 1 is decimal 1
-"c0824fb1-6a0a-4e9a-a262-c6c00af99fa8" = true
+[c0824fb1-6a0a-4e9a-a262-c6c00af99fa8]
+description = "binary 1 is decimal 1"
 
-# binary 10 is decimal 2
-"4d2834fb-3cc3-4159-a8fd-da1098def8ed" = true
+[4d2834fb-3cc3-4159-a8fd-da1098def8ed]
+description = "binary 10 is decimal 2"
 
-# binary 11 is decimal 3
-"b7b2b649-4a7c-4808-9eb9-caf00529bac6" = true
+[b7b2b649-4a7c-4808-9eb9-caf00529bac6]
+description = "binary 11 is decimal 3"
 
-# binary 100 is decimal 4
-"de761aff-73cd-43c1-9e1f-0417f07b1e4a" = true
+[de761aff-73cd-43c1-9e1f-0417f07b1e4a]
+description = "binary 100 is decimal 4"
 
-# binary 1001 is decimal 9
-"7849a8f7-f4a1-4966-963e-503282d6814c" = true
+[7849a8f7-f4a1-4966-963e-503282d6814c]
+description = "binary 1001 is decimal 9"
 
-# binary 11010 is decimal 26
-"836a101c-aecb-473b-ba78-962408dcda98" = true
+[836a101c-aecb-473b-ba78-962408dcda98]
+description = "binary 11010 is decimal 26"
 
-# binary 10001101000 is decimal 1128
-"1c6822a4-8584-438b-8dd4-40f0f0b66371" = true
+[1c6822a4-8584-438b-8dd4-40f0f0b66371]
+description = "binary 10001101000 is decimal 1128"
 
-# binary ignores leading zeros
-"91ffe632-8374-4016-b1d1-d8400d9f940d" = true
+[91ffe632-8374-4016-b1d1-d8400d9f940d]
+description = "binary ignores leading zeros"
 
-# 2 is not a valid binary digit
-"44f7d8b1-ddc3-4751-8be3-700a538b421c" = true
+[44f7d8b1-ddc3-4751-8be3-700a538b421c]
+description = "2 is not a valid binary digit"
 
-# a number containing a non-binary digit is invalid
-"c263a24d-6870-420f-b783-628feefd7b6e" = true
+[c263a24d-6870-420f-b783-628feefd7b6e]
+description = "a number containing a non-binary digit is invalid"
 
-# a number with trailing non-binary characters is invalid
-"8d81305b-0502-4a07-bfba-051c5526d7f2" = true
+[8d81305b-0502-4a07-bfba-051c5526d7f2]
+description = "a number with trailing non-binary characters is invalid"
 
-# a number with leading non-binary characters is invalid
-"a7f79b6b-039a-4d42-99b4-fcee56679f03" = true
+[a7f79b6b-039a-4d42-99b4-fcee56679f03]
+description = "a number with leading non-binary characters is invalid"
 
-# a number with internal non-binary characters is invalid
-"9e0ece9d-b8aa-46a0-a22b-3bed2e3f741e" = true
+[9e0ece9d-b8aa-46a0-a22b-3bed2e3f741e]
+description = "a number with internal non-binary characters is invalid"
 
-# a number and a word whitespace separated is invalid
-"46c8dd65-0c32-4273-bb0d-f2b111bccfbd" = true
+[46c8dd65-0c32-4273-bb0d-f2b111bccfbd]
+description = "a number and a word whitespace separated is invalid"

--- a/exercises/practice/bowling/.meta/tests.toml
+++ b/exercises/practice/bowling/.meta/tests.toml
@@ -1,91 +1,93 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# should be able to score a game with all zeros
-"656ae006-25c2-438c-a549-f338e7ec7441" = true
+[656ae006-25c2-438c-a549-f338e7ec7441]
+description = "should be able to score a game with all zeros"
 
-# should be able to score a game with no strikes or spares
-"f85dcc56-cd6b-4875-81b3-e50921e3597b" = true
+[f85dcc56-cd6b-4875-81b3-e50921e3597b]
+description = "should be able to score a game with no strikes or spares"
 
-# a spare followed by zeros is worth ten points
-"d1f56305-3ac2-4fe0-8645-0b37e3073e20" = true
+[d1f56305-3ac2-4fe0-8645-0b37e3073e20]
+description = "a spare followed by zeros is worth ten points"
 
-# points scored in the roll after a spare are counted twice
-"0b8c8bb7-764a-4287-801a-f9e9012f8be4" = true
+[0b8c8bb7-764a-4287-801a-f9e9012f8be4]
+description = "points scored in the roll after a spare are counted twice"
 
-# consecutive spares each get a one roll bonus
-"4d54d502-1565-4691-84cd-f29a09c65bea" = true
+[4d54d502-1565-4691-84cd-f29a09c65bea]
+description = "consecutive spares each get a one roll bonus"
 
-# a spare in the last frame gets a one roll bonus that is counted once
-"e5c9cf3d-abbe-4b74-ad48-34051b2b08c0" = true
+[e5c9cf3d-abbe-4b74-ad48-34051b2b08c0]
+description = "a spare in the last frame gets a one roll bonus that is counted once"
 
-# a strike earns ten points in a frame with a single roll
-"75269642-2b34-4b72-95a4-9be28ab16902" = true
+[75269642-2b34-4b72-95a4-9be28ab16902]
+description = "a strike earns ten points in a frame with a single roll"
 
-# points scored in the two rolls after a strike are counted twice as a bonus
-"037f978c-5d01-4e49-bdeb-9e20a2e6f9a6" = true
+[037f978c-5d01-4e49-bdeb-9e20a2e6f9a6]
+description = "points scored in the two rolls after a strike are counted twice as a bonus"
 
-# consecutive strikes each get the two roll bonus
-"1635e82b-14ec-4cd1-bce4-4ea14bd13a49" = true
+[1635e82b-14ec-4cd1-bce4-4ea14bd13a49]
+description = "consecutive strikes each get the two roll bonus"
 
-# a strike in the last frame gets a two roll bonus that is counted once
-"e483e8b6-cb4b-4959-b310-e3982030d766" = true
+[e483e8b6-cb4b-4959-b310-e3982030d766]
+description = "a strike in the last frame gets a two roll bonus that is counted once"
 
-# rolling a spare with the two roll bonus does not get a bonus roll
-"9d5c87db-84bc-4e01-8e95-53350c8af1f8" = true
+[9d5c87db-84bc-4e01-8e95-53350c8af1f8]
+description = "rolling a spare with the two roll bonus does not get a bonus roll"
 
-# strikes with the two roll bonus do not get bonus rolls
-"576faac1-7cff-4029-ad72-c16bcada79b5" = true
+[576faac1-7cff-4029-ad72-c16bcada79b5]
+description = "strikes with the two roll bonus do not get bonus rolls"
 
-# a strike with the one roll bonus after a spare in the last frame does not get a bonus
-"72e24404-b6c6-46af-b188-875514c0377b" = true
+[72e24404-b6c6-46af-b188-875514c0377b]
+description = "a strike with the one roll bonus after a spare in the last frame does not get a bonus"
 
-# all strikes is a perfect game
-"62ee4c72-8ee8-4250-b794-234f1fec17b1" = true
+[62ee4c72-8ee8-4250-b794-234f1fec17b1]
+description = "all strikes is a perfect game"
 
-# rolls cannot score negative points
-"1245216b-19c6-422c-b34b-6e4012d7459f" = true
+[1245216b-19c6-422c-b34b-6e4012d7459f]
+description = "rolls cannot score negative points"
 
-# a roll cannot score more than 10 points
-"5fcbd206-782c-4faa-8f3a-be5c538ba841" = true
+[5fcbd206-782c-4faa-8f3a-be5c538ba841]
+description = "a roll cannot score more than 10 points"
 
-# two rolls in a frame cannot score more than 10 points
-"fb023c31-d842-422d-ad7e-79ce1db23c21" = true
+[fb023c31-d842-422d-ad7e-79ce1db23c21]
+description = "two rolls in a frame cannot score more than 10 points"
 
-# bonus roll after a strike in the last frame cannot score more than 10 points
-"6082d689-d677-4214-80d7-99940189381b" = true
+[6082d689-d677-4214-80d7-99940189381b]
+description = "bonus roll after a strike in the last frame cannot score more than 10 points"
 
-# two bonus rolls after a strike in the last frame cannot score more than 10 points
-"e9565fe6-510a-4675-ba6b-733a56767a45" = true
+[e9565fe6-510a-4675-ba6b-733a56767a45]
+description = "two bonus rolls after a strike in the last frame cannot score more than 10 points"
 
-# two bonus rolls after a strike in the last frame can score more than 10 points if one is a strike
-"2f6acf99-448e-4282-8103-0b9c7df99c3d" = true
+[2f6acf99-448e-4282-8103-0b9c7df99c3d]
+description = "two bonus rolls after a strike in the last frame can score more than 10 points if one is a strike"
 
-# the second bonus rolls after a strike in the last frame cannot be a strike if the first one is not a strike
-"6380495a-8bc4-4cdb-a59f-5f0212dbed01" = true
+[6380495a-8bc4-4cdb-a59f-5f0212dbed01]
+description = "the second bonus rolls after a strike in the last frame cannot be a strike if the first one is not a strike"
 
-# second bonus roll after a strike in the last frame cannot score more than 10 points
-"2b2976ea-446c-47a3-9817-42777f09fe7e" = true
+[2b2976ea-446c-47a3-9817-42777f09fe7e]
+description = "second bonus roll after a strike in the last frame cannot score more than 10 points"
 
-# an unstarted game cannot be scored
-"29220245-ac8d-463d-bc19-98a94cfada8a" = true
+[29220245-ac8d-463d-bc19-98a94cfada8a]
+description = "an unstarted game cannot be scored"
 
-# an incomplete game cannot be scored
-"4473dc5d-1f86-486f-bf79-426a52ddc955" = true
+[4473dc5d-1f86-486f-bf79-426a52ddc955]
+description = "an incomplete game cannot be scored"
 
-# cannot roll if game already has ten frames
-"2ccb8980-1b37-4988-b7d1-e5701c317df3" = true
+[2ccb8980-1b37-4988-b7d1-e5701c317df3]
+description = "cannot roll if game already has ten frames"
 
-# bonus rolls for a strike in the last frame must be rolled before score can be calculated
-"4864f09b-9df3-4b65-9924-c595ed236f1b" = true
+[4864f09b-9df3-4b65-9924-c595ed236f1b]
+description = "bonus rolls for a strike in the last frame must be rolled before score can be calculated"
 
-# both bonus rolls for a strike in the last frame must be rolled before score can be calculated
-"537f4e37-4b51-4d1c-97e2-986eb37b2ac1" = true
+[537f4e37-4b51-4d1c-97e2-986eb37b2ac1]
+description = "both bonus rolls for a strike in the last frame must be rolled before score can be calculated"
 
-# bonus roll for a spare in the last frame must be rolled before score can be calculated
-"8134e8c1-4201-4197-bf9f-1431afcde4b9" = true
+[8134e8c1-4201-4197-bf9f-1431afcde4b9]
+description = "bonus roll for a spare in the last frame must be rolled before score can be calculated"
 
-# cannot roll after bonus roll for spare
-"9d4a9a55-134a-4bad-bae8-3babf84bd570" = true
+[9d4a9a55-134a-4bad-bae8-3babf84bd570]
+description = "cannot roll after bonus roll for spare"
 
-# cannot roll after bonus rolls for strike
-"d3e02652-a799-4ae3-b53b-68582cc604be" = true
+[d3e02652-a799-4ae3-b53b-68582cc604be]
+description = "cannot roll after bonus rolls for strike"

--- a/exercises/practice/clock/.meta/tests.toml
+++ b/exercises/practice/clock/.meta/tests.toml
@@ -1,157 +1,159 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# on the hour
-"a577bacc-106b-496e-9792-b3083ea8705e" = true
+[a577bacc-106b-496e-9792-b3083ea8705e]
+description = "on the hour"
 
-# past the hour
-"b5d0c360-3b88-489b-8e84-68a1c7a4fa23" = true
+[b5d0c360-3b88-489b-8e84-68a1c7a4fa23]
+description = "past the hour"
 
-# midnight is zero hours
-"473223f4-65f3-46ff-a9f7-7663c7e59440" = true
+[473223f4-65f3-46ff-a9f7-7663c7e59440]
+description = "midnight is zero hours"
 
-# hour rolls over
-"ca95d24a-5924-447d-9a96-b91c8334725c" = true
+[ca95d24a-5924-447d-9a96-b91c8334725c]
+description = "hour rolls over"
 
-# hour rolls over continuously
-"f3826de0-0925-4d69-8ac8-89aea7e52b78" = true
+[f3826de0-0925-4d69-8ac8-89aea7e52b78]
+description = "hour rolls over continuously"
 
-# sixty minutes is next hour
-"a02f7edf-dfd4-4b11-b21a-86de3cc6a95c" = true
+[a02f7edf-dfd4-4b11-b21a-86de3cc6a95c]
+description = "sixty minutes is next hour"
 
-# minutes roll over
-"8f520df6-b816-444d-b90f-8a477789beb5" = true
+[8f520df6-b816-444d-b90f-8a477789beb5]
+description = "minutes roll over"
 
-# minutes roll over continuously
-"c75c091b-47ac-4655-8d40-643767fc4eed" = true
+[c75c091b-47ac-4655-8d40-643767fc4eed]
+description = "minutes roll over continuously"
 
-# hour and minutes roll over
-"06343ecb-cf39-419d-a3f5-dcbae0cc4c57" = true
+[06343ecb-cf39-419d-a3f5-dcbae0cc4c57]
+description = "hour and minutes roll over"
 
-# hour and minutes roll over continuously
-"be60810e-f5d9-4b58-9351-a9d1e90e660c" = true
+[be60810e-f5d9-4b58-9351-a9d1e90e660c]
+description = "hour and minutes roll over continuously"
 
-# hour and minutes roll over to exactly midnight
-"1689107b-0b5c-4bea-aad3-65ec9859368a" = true
+[1689107b-0b5c-4bea-aad3-65ec9859368a]
+description = "hour and minutes roll over to exactly midnight"
 
-# negative hour
-"d3088ee8-91b7-4446-9e9d-5e2ad6219d91" = true
+[d3088ee8-91b7-4446-9e9d-5e2ad6219d91]
+description = "negative hour"
 
-# negative hour rolls over
-"77ef6921-f120-4d29-bade-80d54aa43b54" = true
+[77ef6921-f120-4d29-bade-80d54aa43b54]
+description = "negative hour rolls over"
 
-# negative hour rolls over continuously
-"359294b5-972f-4546-bb9a-a85559065234" = true
+[359294b5-972f-4546-bb9a-a85559065234]
+description = "negative hour rolls over continuously"
 
-# negative minutes
-"509db8b7-ac19-47cc-bd3a-a9d2f30b03c0" = true
+[509db8b7-ac19-47cc-bd3a-a9d2f30b03c0]
+description = "negative minutes"
 
-# negative minutes roll over
-"5d6bb225-130f-4084-84fd-9e0df8996f2a" = true
+[5d6bb225-130f-4084-84fd-9e0df8996f2a]
+description = "negative minutes roll over"
 
-# negative minutes roll over continuously
-"d483ceef-b520-4f0c-b94a-8d2d58cf0484" = true
+[d483ceef-b520-4f0c-b94a-8d2d58cf0484]
+description = "negative minutes roll over continuously"
 
-# negative sixty minutes is previous hour
-"1cd19447-19c6-44bf-9d04-9f8305ccb9ea" = true
+[1cd19447-19c6-44bf-9d04-9f8305ccb9ea]
+description = "negative sixty minutes is previous hour"
 
-# negative hour and minutes both roll over
-"9d3053aa-4f47-4afc-bd45-d67a72cef4dc" = true
+[9d3053aa-4f47-4afc-bd45-d67a72cef4dc]
+description = "negative hour and minutes both roll over"
 
-# negative hour and minutes both roll over continuously
-"51d41fcf-491e-4ca0-9cae-2aa4f0163ad4" = true
+[51d41fcf-491e-4ca0-9cae-2aa4f0163ad4]
+description = "negative hour and minutes both roll over continuously"
 
-# add minutes
-"d098e723-ad29-4ef9-997a-2693c4c9d89a" = true
+[d098e723-ad29-4ef9-997a-2693c4c9d89a]
+description = "add minutes"
 
-# add no minutes
-"b6ec8f38-e53e-4b22-92a7-60dab1f485f4" = true
+[b6ec8f38-e53e-4b22-92a7-60dab1f485f4]
+description = "add no minutes"
 
-# add to next hour
-"efd349dd-0785-453e-9ff8-d7452a8e7269" = true
+[efd349dd-0785-453e-9ff8-d7452a8e7269]
+description = "add to next hour"
 
-# add more than one hour
-"749890f7-aba9-4702-acce-87becf4ef9fe" = true
+[749890f7-aba9-4702-acce-87becf4ef9fe]
+description = "add more than one hour"
 
-# add more than two hours with carry
-"da63e4c1-1584-46e3-8d18-c9dc802c1713" = true
+[da63e4c1-1584-46e3-8d18-c9dc802c1713]
+description = "add more than two hours with carry"
 
-# add across midnight
-"be167a32-3d33-4cec-a8bc-accd47ddbb71" = true
+[be167a32-3d33-4cec-a8bc-accd47ddbb71]
+description = "add across midnight"
 
-# add more than one day (1500 min = 25 hrs)
-"6672541e-cdae-46e4-8be7-a820cc3be2a8" = true
+[6672541e-cdae-46e4-8be7-a820cc3be2a8]
+description = "add more than one day (1500 min = 25 hrs)"
 
-# add more than two days
-"1918050d-c79b-4cb7-b707-b607e2745c7e" = true
+[1918050d-c79b-4cb7-b707-b607e2745c7e]
+description = "add more than two days"
 
-# subtract minutes
-"37336cac-5ede-43a5-9026-d426cbe40354" = true
+[37336cac-5ede-43a5-9026-d426cbe40354]
+description = "subtract minutes"
 
-# subtract to previous hour
-"0aafa4d0-3b5f-4b12-b3af-e3a9e09c047b" = true
+[0aafa4d0-3b5f-4b12-b3af-e3a9e09c047b]
+description = "subtract to previous hour"
 
-# subtract more than an hour
-"9b4e809c-612f-4b15-aae0-1df0acb801b9" = true
+[9b4e809c-612f-4b15-aae0-1df0acb801b9]
+description = "subtract more than an hour"
 
-# subtract across midnight
-"8b04bb6a-3d33-4e6c-8de9-f5de6d2c70d6" = true
+[8b04bb6a-3d33-4e6c-8de9-f5de6d2c70d6]
+description = "subtract across midnight"
 
-# subtract more than two hours
-"07c3bbf7-ce4d-4658-86e8-4a77b7a5ccd9" = true
+[07c3bbf7-ce4d-4658-86e8-4a77b7a5ccd9]
+description = "subtract more than two hours"
 
-# subtract more than two hours with borrow
-"90ac8a1b-761c-4342-9c9c-cdc3ed5db097" = true
+[90ac8a1b-761c-4342-9c9c-cdc3ed5db097]
+description = "subtract more than two hours with borrow"
 
-# subtract more than one day (1500 min = 25 hrs)
-"2149f985-7136-44ad-9b29-ec023a97a2b7" = true
+[2149f985-7136-44ad-9b29-ec023a97a2b7]
+description = "subtract more than one day (1500 min = 25 hrs)"
 
-# subtract more than two days
-"ba11dbf0-ac27-4acb-ada9-3b853ec08c97" = true
+[ba11dbf0-ac27-4acb-ada9-3b853ec08c97]
+description = "subtract more than two days"
 
-# clocks with same time
-"f2fdad51-499f-4c9b-a791-b28c9282e311" = true
+[f2fdad51-499f-4c9b-a791-b28c9282e311]
+description = "clocks with same time"
 
-# clocks a minute apart
-"5d409d4b-f862-4960-901e-ec430160b768" = true
+[5d409d4b-f862-4960-901e-ec430160b768]
+description = "clocks a minute apart"
 
-# clocks an hour apart
-"a6045fcf-2b52-4a47-8bb2-ef10a064cba5" = true
+[a6045fcf-2b52-4a47-8bb2-ef10a064cba5]
+description = "clocks an hour apart"
 
-# clocks with hour overflow
-"66b12758-0be5-448b-a13c-6a44bce83527" = true
+[66b12758-0be5-448b-a13c-6a44bce83527]
+description = "clocks with hour overflow"
 
-# clocks with hour overflow by several days
-"2b19960c-212e-4a71-9aac-c581592f8111" = true
+[2b19960c-212e-4a71-9aac-c581592f8111]
+description = "clocks with hour overflow by several days"
 
-# clocks with negative hour
-"6f8c6541-afac-4a92-b0c2-b10d4e50269f" = true
+[6f8c6541-afac-4a92-b0c2-b10d4e50269f]
+description = "clocks with negative hour"
 
-# clocks with negative hour that wraps
-"bb9d5a68-e324-4bf5-a75e-0e9b1f97a90d" = true
+[bb9d5a68-e324-4bf5-a75e-0e9b1f97a90d]
+description = "clocks with negative hour that wraps"
 
-# clocks with negative hour that wraps multiple times
-"56c0326d-565b-4d19-a26f-63b3205778b7" = true
+[56c0326d-565b-4d19-a26f-63b3205778b7]
+description = "clocks with negative hour that wraps multiple times"
 
-# clocks with minute overflow
-"c90b9de8-ddff-4ffe-9858-da44a40fdbc2" = true
+[c90b9de8-ddff-4ffe-9858-da44a40fdbc2]
+description = "clocks with minute overflow"
 
-# clocks with minute overflow by several days
-"533a3dc5-59a7-491b-b728-a7a34fe325de" = true
+[533a3dc5-59a7-491b-b728-a7a34fe325de]
+description = "clocks with minute overflow by several days"
 
-# clocks with negative minute
-"fff49e15-f7b7-4692-a204-0f6052d62636" = true
+[fff49e15-f7b7-4692-a204-0f6052d62636]
+description = "clocks with negative minute"
 
-# clocks with negative minute that wraps
-"605c65bb-21bd-43eb-8f04-878edf508366" = true
+[605c65bb-21bd-43eb-8f04-878edf508366]
+description = "clocks with negative minute that wraps"
 
-# clocks with negative minute that wraps multiple times
-"b87e64ed-212a-4335-91fd-56da8421d077" = true
+[b87e64ed-212a-4335-91fd-56da8421d077]
+description = "clocks with negative minute that wraps multiple times"
 
-# clocks with negative hours and minutes
-"822fbf26-1f3b-4b13-b9bf-c914816b53dd" = true
+[822fbf26-1f3b-4b13-b9bf-c914816b53dd]
+description = "clocks with negative hours and minutes"
 
-# clocks with negative hours and minutes that wrap
-"e787bccd-cf58-4a1d-841c-ff80eaaccfaa" = true
+[e787bccd-cf58-4a1d-841c-ff80eaaccfaa]
+description = "clocks with negative hours and minutes that wrap"
 
-# full clock and zeroed clock
-"96969ca8-875a-48a1-86ae-257a528c44f5" = true
+[96969ca8-875a-48a1-86ae-257a528c44f5]
+description = "full clock and zeroed clock"

--- a/exercises/practice/collatz-conjecture/.meta/tests.toml
+++ b/exercises/practice/collatz-conjecture/.meta/tests.toml
@@ -1,19 +1,21 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# zero steps for one
-"540a3d51-e7a6-47a5-92a3-4ad1838f0bfd" = true
+[540a3d51-e7a6-47a5-92a3-4ad1838f0bfd]
+description = "zero steps for one"
 
-# divide if even
-"3d76a0a6-ea84-444a-821a-f7857c2c1859" = true
+[3d76a0a6-ea84-444a-821a-f7857c2c1859]
+description = "divide if even"
 
-# even and odd steps
-"754dea81-123c-429e-b8bc-db20b05a87b9" = true
+[754dea81-123c-429e-b8bc-db20b05a87b9]
+description = "even and odd steps"
 
-# large number of even and odd steps
-"ecfd0210-6f85-44f6-8280-f65534892ff6" = true
+[ecfd0210-6f85-44f6-8280-f65534892ff6]
+description = "large number of even and odd steps"
 
-# zero is an error
-"7d4750e6-def9-4b86-aec7-9f7eb44f95a3" = true
+[7d4750e6-def9-4b86-aec7-9f7eb44f95a3]
+description = "zero is an error"
 
-# negative value is an error
-"c6c795bf-a288-45e9-86a1-841359ad426d" = true
+[c6c795bf-a288-45e9-86a1-841359ad426d]
+description = "negative value is an error"

--- a/exercises/practice/darts/.meta/tests.toml
+++ b/exercises/practice/darts/.meta/tests.toml
@@ -1,40 +1,42 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# Missed target
-"9033f731-0a3a-4d9c-b1c0-34a1c8362afb" = true
+[9033f731-0a3a-4d9c-b1c0-34a1c8362afb]
+description = "Missed target"
 
-# On the outer circle
-"4c9f6ff4-c489-45fd-be8a-1fcb08b4d0ba" = true
+[4c9f6ff4-c489-45fd-be8a-1fcb08b4d0ba]
+description = "On the outer circle"
 
-# On the middle circle
-"14378687-ee58-4c9b-a323-b089d5274be8" = true
+[14378687-ee58-4c9b-a323-b089d5274be8]
+description = "On the middle circle"
 
-# On the inner circle
-"849e2e63-85bd-4fed-bc3b-781ae962e2c9" = true
+[849e2e63-85bd-4fed-bc3b-781ae962e2c9]
+description = "On the inner circle"
 
-# Exactly on centre
-"1c5ffd9f-ea66-462f-9f06-a1303de5a226" = true
+[1c5ffd9f-ea66-462f-9f06-a1303de5a226]
+description = "Exactly on centre"
 
-# Near the centre
-"b65abce3-a679-4550-8115-4b74bda06088" = true
+[b65abce3-a679-4550-8115-4b74bda06088]
+description = "Near the centre"
 
-# Just within the inner circle
-"66c29c1d-44f5-40cf-9927-e09a1305b399" = true
+[66c29c1d-44f5-40cf-9927-e09a1305b399]
+description = "Just within the inner circle"
 
-# Just outside the inner circle
-"d1012f63-c97c-4394-b944-7beb3d0b141a" = true
+[d1012f63-c97c-4394-b944-7beb3d0b141a]
+description = "Just outside the inner circle"
 
-# Just within the middle circle
-"ab2b5666-b0b4-49c3-9b27-205e790ed945" = true
+[ab2b5666-b0b4-49c3-9b27-205e790ed945]
+description = "Just within the middle circle"
 
-# Just outside the middle circle
-"70f1424e-d690-4860-8caf-9740a52c0161" = true
+[70f1424e-d690-4860-8caf-9740a52c0161]
+description = "Just outside the middle circle"
 
-# Just within the outer circle
-"a7dbf8db-419c-4712-8a7f-67602b69b293" = true
+[a7dbf8db-419c-4712-8a7f-67602b69b293]
+description = "Just within the outer circle"
 
-# Just outside the outer circle
-"e0f39315-9f9a-4546-96e4-a9475b885aa7" = true
+[e0f39315-9f9a-4546-96e4-a9475b885aa7]
+description = "Just outside the outer circle"
 
-# Asymmetric position between the inner and middle circles
-"045d7d18-d863-4229-818e-b50828c75d19" = true
+[045d7d18-d863-4229-818e-b50828c75d19]
+description = "Asymmetric position between the inner and middle circles"

--- a/exercises/practice/diamond/.meta/tests.toml
+++ b/exercises/practice/diamond/.meta/tests.toml
@@ -1,16 +1,18 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# Degenerate case with a single 'A' row
-"202fb4cc-6a38-4883-9193-a29d5cb92076" = true
+[202fb4cc-6a38-4883-9193-a29d5cb92076]
+description = "Degenerate case with a single 'A' row"
 
-# Degenerate case with no row containing 3 distinct groups of spaces
-"bd6a6d78-9302-42e9-8f60-ac1461e9abae" = true
+[bd6a6d78-9302-42e9-8f60-ac1461e9abae]
+description = "Degenerate case with no row containing 3 distinct groups of spaces"
 
-# Smallest non-degenerate case with odd diamond side length
-"af8efb49-14ed-447f-8944-4cc59ce3fd76" = true
+[af8efb49-14ed-447f-8944-4cc59ce3fd76]
+description = "Smallest non-degenerate case with odd diamond side length"
 
-# Smallest non-degenerate case with even diamond side length
-"e0c19a95-9888-4d05-86a0-fa81b9e70d1d" = true
+[e0c19a95-9888-4d05-86a0-fa81b9e70d1d]
+description = "Smallest non-degenerate case with even diamond side length"
 
-# Largest possible diamond
-"82ea9aa9-4c0e-442a-b07e-40204e925944" = true
+[82ea9aa9-4c0e-442a-b07e-40204e925944]
+description = "Largest possible diamond"

--- a/exercises/practice/etl/.meta/tests.toml
+++ b/exercises/practice/etl/.meta/tests.toml
@@ -1,13 +1,15 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# single letter
-"78a7a9f9-4490-4a47-8ee9-5a38bb47d28f" = true
+[78a7a9f9-4490-4a47-8ee9-5a38bb47d28f]
+description = "single letter"
 
-# single score with multiple letters
-"60dbd000-451d-44c7-bdbb-97c73ac1f497" = true
+[60dbd000-451d-44c7-bdbb-97c73ac1f497]
+description = "single score with multiple letters"
 
-# multiple scores with multiple letters
-"f5c5de0c-301f-4fdd-a0e5-df97d4214f54" = true
+[f5c5de0c-301f-4fdd-a0e5-df97d4214f54]
+description = "multiple scores with multiple letters"
 
-# multiple scores with differing numbers of letters
-"5db8ea89-ecb4-4dcd-902f-2b418cc87b9d" = true
+[5db8ea89-ecb4-4dcd-902f-2b418cc87b9d]
+description = "multiple scores with differing numbers of letters"

--- a/exercises/practice/flatten-array/.meta/tests.toml
+++ b/exercises/practice/flatten-array/.meta/tests.toml
@@ -1,19 +1,21 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# no nesting
-"d268b919-963c-442d-9f07-82b93f1b518c" = true
+[d268b919-963c-442d-9f07-82b93f1b518c]
+description = "no nesting"
 
-# flattens array with just integers present
-"c84440cc-bb3a-48a6-862c-94cf23f2815d" = true
+[c84440cc-bb3a-48a6-862c-94cf23f2815d]
+description = "flattens array with just integers present"
 
-# 5 level nesting
-"d3d99d39-6be5-44f5-a31d-6037d92ba34f" = true
+[d3d99d39-6be5-44f5-a31d-6037d92ba34f]
+description = "5 level nesting"
 
-# 6 level nesting
-"d572bdba-c127-43ed-bdcd-6222ac83d9f7" = true
+[d572bdba-c127-43ed-bdcd-6222ac83d9f7]
+description = "6 level nesting"
 
-# 6 level nest list with null values
-"ef1d4790-1b1e-4939-a179-51ace0829dbd" = true
+[ef1d4790-1b1e-4939-a179-51ace0829dbd]
+description = "6 level nest list with null values"
 
-# all values in nested list are null
-"85721643-705a-4150-93ab-7ae398e2942d" = true
+[85721643-705a-4150-93ab-7ae398e2942d]
+description = "all values in nested list are null"

--- a/exercises/practice/forth/.meta/tests.toml
+++ b/exercises/practice/forth/.meta/tests.toml
@@ -1,139 +1,141 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# numbers just get pushed onto the stack
-"9962203f-f00a-4a85-b404-8a8ecbcec09d" = true
+[9962203f-f00a-4a85-b404-8a8ecbcec09d]
+description = "numbers just get pushed onto the stack"
 
-# can add two numbers
-"9e69588e-a3d8-41a3-a371-ea02206c1e6e" = true
+[9e69588e-a3d8-41a3-a371-ea02206c1e6e]
+description = "can add two numbers"
 
-# errors if there is nothing on the stack
-"52336dd3-30da-4e5c-8523-bdf9a3427657" = true
+[52336dd3-30da-4e5c-8523-bdf9a3427657]
+description = "errors if there is nothing on the stack"
 
-# errors if there is only one value on the stack
-"06efb9a4-817a-435e-b509-06166993c1b8" = true
+[06efb9a4-817a-435e-b509-06166993c1b8]
+description = "errors if there is only one value on the stack"
 
-# can subtract two numbers
-"09687c99-7bbc-44af-8526-e402f997ccbf" = true
+[09687c99-7bbc-44af-8526-e402f997ccbf]
+description = "can subtract two numbers"
 
-# errors if there is nothing on the stack
-"5d63eee2-1f7d-4538-b475-e27682ab8032" = true
+[5d63eee2-1f7d-4538-b475-e27682ab8032]
+description = "errors if there is nothing on the stack"
 
-# errors if there is only one value on the stack
-"b3cee1b2-9159-418a-b00d-a1bb3765c23b" = true
+[b3cee1b2-9159-418a-b00d-a1bb3765c23b]
+description = "errors if there is only one value on the stack"
 
-# can multiply two numbers
-"5df0ceb5-922e-401f-974d-8287427dbf21" = true
+[5df0ceb5-922e-401f-974d-8287427dbf21]
+description = "can multiply two numbers"
 
-# errors if there is nothing on the stack
-"9e004339-15ac-4063-8ec1-5720f4e75046" = true
+[9e004339-15ac-4063-8ec1-5720f4e75046]
+description = "errors if there is nothing on the stack"
 
-# errors if there is only one value on the stack
-"8ba4b432-9f94-41e0-8fae-3b3712bd51b3" = true
+[8ba4b432-9f94-41e0-8fae-3b3712bd51b3]
+description = "errors if there is only one value on the stack"
 
-# can divide two numbers
-"e74c2204-b057-4cff-9aa9-31c7c97a93f5" = true
+[e74c2204-b057-4cff-9aa9-31c7c97a93f5]
+description = "can divide two numbers"
 
-# performs integer division
-"54f6711c-4b14-4bb0-98ad-d974a22c4620" = true
+[54f6711c-4b14-4bb0-98ad-d974a22c4620]
+description = "performs integer division"
 
-# errors if dividing by zero
-"a5df3219-29b4-4d2f-b427-81f82f42a3f1" = true
+[a5df3219-29b4-4d2f-b427-81f82f42a3f1]
+description = "errors if dividing by zero"
 
-# errors if there is nothing on the stack
-"1d5bb6b3-6749-4e02-8a79-b5d4d334cb8a" = true
+[1d5bb6b3-6749-4e02-8a79-b5d4d334cb8a]
+description = "errors if there is nothing on the stack"
 
-# errors if there is only one value on the stack
-"d5547f43-c2ff-4d5c-9cb0-2a4f6684c20d" = true
+[d5547f43-c2ff-4d5c-9cb0-2a4f6684c20d]
+description = "errors if there is only one value on the stack"
 
-# addition and subtraction
-"ee28d729-6692-4a30-b9be-0d830c52a68c" = true
+[ee28d729-6692-4a30-b9be-0d830c52a68c]
+description = "addition and subtraction"
 
-# multiplication and division
-"40b197da-fa4b-4aca-a50b-f000d19422c1" = true
+[40b197da-fa4b-4aca-a50b-f000d19422c1]
+description = "multiplication and division"
 
-# copies a value on the stack
-"c5758235-6eef-4bf6-ab62-c878e50b9957" = true
+[c5758235-6eef-4bf6-ab62-c878e50b9957]
+description = "copies a value on the stack"
 
-# copies the top value on the stack
-"f6889006-5a40-41e7-beb3-43b09e5a22f4" = true
+[f6889006-5a40-41e7-beb3-43b09e5a22f4]
+description = "copies the top value on the stack"
 
-# errors if there is nothing on the stack
-"40b7569c-8401-4bd4-a30d-9adf70d11bc4" = true
+[40b7569c-8401-4bd4-a30d-9adf70d11bc4]
+description = "errors if there is nothing on the stack"
 
-# removes the top value on the stack if it is the only one
-"1971da68-1df2-4569-927a-72bf5bb7263c" = true
+[1971da68-1df2-4569-927a-72bf5bb7263c]
+description = "removes the top value on the stack if it is the only one"
 
-# removes the top value on the stack if it is not the only one
-"8929d9f2-4a78-4e0f-90ad-be1a0f313fd9" = true
+[8929d9f2-4a78-4e0f-90ad-be1a0f313fd9]
+description = "removes the top value on the stack if it is not the only one"
 
-# errors if there is nothing on the stack
-"6dd31873-6dd7-4cb8-9e90-7daa33ba045c" = true
+[6dd31873-6dd7-4cb8-9e90-7daa33ba045c]
+description = "errors if there is nothing on the stack"
 
-# swaps the top two values on the stack if they are the only ones
-"3ee68e62-f98a-4cce-9e6c-8aae6c65a4e3" = true
+[3ee68e62-f98a-4cce-9e6c-8aae6c65a4e3]
+description = "swaps the top two values on the stack if they are the only ones"
 
-# swaps the top two values on the stack if they are not the only ones
-"8ce869d5-a503-44e4-ab55-1da36816ff1c" = true
+[8ce869d5-a503-44e4-ab55-1da36816ff1c]
+description = "swaps the top two values on the stack if they are not the only ones"
 
-# errors if there is nothing on the stack
-"74ba5b2a-b028-4759-9176-c5c0e7b2b154" = true
+[74ba5b2a-b028-4759-9176-c5c0e7b2b154]
+description = "errors if there is nothing on the stack"
 
-# errors if there is only one value on the stack
-"dd52e154-5d0d-4a5c-9e5d-73eb36052bc8" = true
+[dd52e154-5d0d-4a5c-9e5d-73eb36052bc8]
+description = "errors if there is only one value on the stack"
 
-# copies the second element if there are only two
-"a2654074-ba68-4f93-b014-6b12693a8b50" = true
+[a2654074-ba68-4f93-b014-6b12693a8b50]
+description = "copies the second element if there are only two"
 
-# copies the second element if there are more than two
-"c5b51097-741a-4da7-8736-5c93fa856339" = true
+[c5b51097-741a-4da7-8736-5c93fa856339]
+description = "copies the second element if there are more than two"
 
-# errors if there is nothing on the stack
-"6e1703a6-5963-4a03-abba-02e77e3181fd" = true
+[6e1703a6-5963-4a03-abba-02e77e3181fd]
+description = "errors if there is nothing on the stack"
 
-# errors if there is only one value on the stack
-"ee574dc4-ef71-46f6-8c6a-b4af3a10c45f" = true
+[ee574dc4-ef71-46f6-8c6a-b4af3a10c45f]
+description = "errors if there is only one value on the stack"
 
-# can consist of built-in words
-"ed45cbbf-4dbf-4901-825b-54b20dbee53b" = true
+[ed45cbbf-4dbf-4901-825b-54b20dbee53b]
+description = "can consist of built-in words"
 
-# execute in the right order
-"2726ea44-73e4-436b-bc2b-5ff0c6aa014b" = true
+[2726ea44-73e4-436b-bc2b-5ff0c6aa014b]
+description = "execute in the right order"
 
-# can override other user-defined words
-"9e53c2d0-b8ef-4ad8-b2c9-a559b421eb33" = true
+[9e53c2d0-b8ef-4ad8-b2c9-a559b421eb33]
+description = "can override other user-defined words"
 
-# can override built-in words
-"669db3f3-5bd6-4be0-83d1-618cd6e4984b" = true
+[669db3f3-5bd6-4be0-83d1-618cd6e4984b]
+description = "can override built-in words"
 
-# can override built-in operators
-"588de2f0-c56e-4c68-be0b-0bb1e603c500" = true
+[588de2f0-c56e-4c68-be0b-0bb1e603c500]
+description = "can override built-in operators"
 
-# can use different words with the same name
-"ac12aaaf-26c6-4a10-8b3c-1c958fa2914c" = true
+[ac12aaaf-26c6-4a10-8b3c-1c958fa2914c]
+description = "can use different words with the same name"
 
-# can define word that uses word with the same name
-"53f82ef0-2750-4ccb-ac04-5d8c1aefabb1" = true
+[53f82ef0-2750-4ccb-ac04-5d8c1aefabb1]
+description = "can define word that uses word with the same name"
 
-# cannot redefine numbers
-"35958cee-a976-4a0f-9378-f678518fa322" = true
+[35958cee-a976-4a0f-9378-f678518fa322]
+description = "cannot redefine numbers"
 
-# errors if executing a non-existent word
-"5180f261-89dd-491e-b230-62737e09806f" = true
+[5180f261-89dd-491e-b230-62737e09806f]
+description = "errors if executing a non-existent word"
 
-# DUP is case-insensitive
-"7b83bb2e-b0e8-461f-ad3b-96ee2e111ed6" = true
+[7b83bb2e-b0e8-461f-ad3b-96ee2e111ed6]
+description = "DUP is case-insensitive"
 
-# DROP is case-insensitive
-"339ed30b-f5b4-47ff-ab1c-67591a9cd336" = true
+[339ed30b-f5b4-47ff-ab1c-67591a9cd336]
+description = "DROP is case-insensitive"
 
-# SWAP is case-insensitive
-"ee1af31e-1355-4b1b-bb95-f9d0b2961b87" = true
+[ee1af31e-1355-4b1b-bb95-f9d0b2961b87]
+description = "SWAP is case-insensitive"
 
-# OVER is case-insensitive
-"acdc3a49-14c8-4cc2-945d-11edee6408fa" = true
+[acdc3a49-14c8-4cc2-945d-11edee6408fa]
+description = "OVER is case-insensitive"
 
-# user-defined words are case-insensitive
-"5934454f-a24f-4efc-9fdd-5794e5f0c23c" = true
+[5934454f-a24f-4efc-9fdd-5794e5f0c23c]
+description = "user-defined words are case-insensitive"
 
-# definitions are case-insensitive
-"037d4299-195f-4be7-a46d-f07ca6280a06" = true
+[037d4299-195f-4be7-a46d-f07ca6280a06]
+description = "definitions are case-insensitive"

--- a/exercises/practice/grade-school/.meta/tests.toml
+++ b/exercises/practice/grade-school/.meta/tests.toml
@@ -1,22 +1,24 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# Adding a student adds them to the sorted roster
-"6d0a30e4-1b4e-472e-8e20-c41702125667" = true
+[6d0a30e4-1b4e-472e-8e20-c41702125667]
+description = "Adding a student adds them to the sorted roster"
 
-# Adding more student adds them to the sorted roster
-"233be705-dd58-4968-889d-fb3c7954c9cc" = true
+[233be705-dd58-4968-889d-fb3c7954c9cc]
+description = "Adding more student adds them to the sorted roster"
 
-# Adding students to different grades adds them to the same sorted roster
-"75a51579-d1d7-407c-a2f8-2166e984e8ab" = true
+[75a51579-d1d7-407c-a2f8-2166e984e8ab]
+description = "Adding students to different grades adds them to the same sorted roster"
 
-# Roster returns an empty list if there are no students enrolled
-"a3f0fb58-f240-4723-8ddc-e644666b85cc" = true
+[a3f0fb58-f240-4723-8ddc-e644666b85cc]
+description = "Roster returns an empty list if there are no students enrolled"
 
-# Student names with grades are displayed in the same sorted roster
-"180a8ff9-5b94-43fc-9db1-d46b4a8c93b6" = true
+[180a8ff9-5b94-43fc-9db1-d46b4a8c93b6]
+description = "Student names with grades are displayed in the same sorted roster"
 
-# Grade returns the students in that grade in alphabetical order
-"1bfbcef1-e4a3-49e8-8d22-f6f9f386187e" = true
+[1bfbcef1-e4a3-49e8-8d22-f6f9f386187e]
+description = "Grade returns the students in that grade in alphabetical order"
 
-# Grade returns an empty list if there are no students in that grade
-"5e67aa3c-a3c6-4407-a183-d8fe59cd1630" = true
+[5e67aa3c-a3c6-4407-a183-d8fe59cd1630]
+description = "Grade returns an empty list if there are no students in that grade"

--- a/exercises/practice/grains/.meta/tests.toml
+++ b/exercises/practice/grains/.meta/tests.toml
@@ -1,34 +1,36 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# 1
-"9fbde8de-36b2-49de-baf2-cd42d6f28405" = true
+[9fbde8de-36b2-49de-baf2-cd42d6f28405]
+description = "1"
 
-# 2
-"ee1f30c2-01d8-4298-b25d-c677331b5e6d" = true
+[ee1f30c2-01d8-4298-b25d-c677331b5e6d]
+description = "2"
 
-# 3
-"10f45584-2fc3-4875-8ec6-666065d1163b" = true
+[10f45584-2fc3-4875-8ec6-666065d1163b]
+description = "3"
 
-# 4
-"a7cbe01b-36f4-4601-b053-c5f6ae055170" = true
+[a7cbe01b-36f4-4601-b053-c5f6ae055170]
+description = "4"
 
-# 16
-"c50acc89-8535-44e4-918f-b848ad2817d4" = true
+[c50acc89-8535-44e4-918f-b848ad2817d4]
+description = "16"
 
-# 32
-"acd81b46-c2ad-4951-b848-80d15ed5a04f" = true
+[acd81b46-c2ad-4951-b848-80d15ed5a04f]
+description = "32"
 
-# 64
-"c73b470a-5efb-4d53-9ac6-c5f6487f227b" = true
+[c73b470a-5efb-4d53-9ac6-c5f6487f227b]
+description = "64"
 
-# square 0 raises an exception
-"1d47d832-3e85-4974-9466-5bd35af484e3" = true
+[1d47d832-3e85-4974-9466-5bd35af484e3]
+description = "square 0 raises an exception"
 
-# negative square raises an exception
-"61974483-eeb2-465e-be54-ca5dde366453" = true
+[61974483-eeb2-465e-be54-ca5dde366453]
+description = "negative square raises an exception"
 
-# square greater than 64 raises an exception
-"a95e4374-f32c-45a7-a10d-ffec475c012f" = true
+[a95e4374-f32c-45a7-a10d-ffec475c012f]
+description = "square greater than 64 raises an exception"
 
-# returns the total number of grains on the board
-"6eb07385-3659-4b45-a6be-9dc474222750" = true
+[6eb07385-3659-4b45-a6be-9dc474222750]
+description = "returns the total number of grains on the board"

--- a/exercises/practice/hamming/.meta/tests.toml
+++ b/exercises/practice/hamming/.meta/tests.toml
@@ -1,28 +1,30 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# empty strands
-"f6dcb64f-03b0-4b60-81b1-3c9dbf47e887" = true
+[f6dcb64f-03b0-4b60-81b1-3c9dbf47e887]
+description = "empty strands"
 
-# single letter identical strands
-"54681314-eee2-439a-9db0-b0636c656156" = true
+[54681314-eee2-439a-9db0-b0636c656156]
+description = "single letter identical strands"
 
-# single letter different strands
-"294479a3-a4c8-478f-8d63-6209815a827b" = true
+[294479a3-a4c8-478f-8d63-6209815a827b]
+description = "single letter different strands"
 
-# long identical strands
-"9aed5f34-5693-4344-9b31-40c692fb5592" = true
+[9aed5f34-5693-4344-9b31-40c692fb5592]
+description = "long identical strands"
 
-# long different strands
-"cd2273a5-c576-46c8-a52b-dee251c3e6e5" = true
+[cd2273a5-c576-46c8-a52b-dee251c3e6e5]
+description = "long different strands"
 
-# disallow first strand longer
-"919f8ef0-b767-4d1b-8516-6379d07fcb28" = true
+[919f8ef0-b767-4d1b-8516-6379d07fcb28]
+description = "disallow first strand longer"
 
-# disallow second strand longer
-"8a2d4ed0-ead5-4fdd-924d-27c4cf56e60e" = true
+[8a2d4ed0-ead5-4fdd-924d-27c4cf56e60e]
+description = "disallow second strand longer"
 
-# disallow left empty strand
-"5dce058b-28d4-4ca7-aa64-adfe4e17784c" = true
+[5dce058b-28d4-4ca7-aa64-adfe4e17784c]
+description = "disallow left empty strand"
 
-# disallow right empty strand
-"38826d4b-16fb-4639-ac3e-ba027dec8b5f" = true
+[38826d4b-16fb-4639-ac3e-ba027dec8b5f]
+description = "disallow right empty strand"

--- a/exercises/practice/hello-world/.meta/tests.toml
+++ b/exercises/practice/hello-world/.meta/tests.toml
@@ -1,4 +1,6 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# Say Hi!
-"af9ffe10-dc13-42d8-a742-e7bdafac449d" = true
+[af9ffe10-dc13-42d8-a742-e7bdafac449d]
+description = "Say Hi!"

--- a/exercises/practice/high-scores/.meta/tests.toml
+++ b/exercises/practice/high-scores/.meta/tests.toml
@@ -1,25 +1,27 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# List of scores
-"1035eb93-2208-4c22-bab8-fef06769a73c" = true
+[1035eb93-2208-4c22-bab8-fef06769a73c]
+description = "List of scores"
 
-# Latest score
-"6aa5dbf5-78fa-4375-b22c-ffaa989732d2" = true
+[6aa5dbf5-78fa-4375-b22c-ffaa989732d2]
+description = "Latest score"
 
-# Personal best
-"b661a2e1-aebf-4f50-9139-0fb817dd12c6" = true
+[b661a2e1-aebf-4f50-9139-0fb817dd12c6]
+description = "Personal best"
 
-# Personal top three from a list of scores
-"3d996a97-c81c-4642-9afc-80b80dc14015" = true
+[3d996a97-c81c-4642-9afc-80b80dc14015]
+description = "Personal top three from a list of scores"
 
-# Personal top highest to lowest
-"1084ecb5-3eb4-46fe-a816-e40331a4e83a" = true
+[1084ecb5-3eb4-46fe-a816-e40331a4e83a]
+description = "Personal top highest to lowest"
 
-# Personal top when there is a tie
-"e6465b6b-5a11-4936-bfe3-35241c4f4f16" = true
+[e6465b6b-5a11-4936-bfe3-35241c4f4f16]
+description = "Personal top when there is a tie"
 
-# Personal top when there are less than 3
-"f73b02af-c8fd-41c9-91b9-c86eaa86bce2" = true
+[f73b02af-c8fd-41c9-91b9-c86eaa86bce2]
+description = "Personal top when there are less than 3"
 
-# Personal top when there is only one
-"16608eae-f60f-4a88-800e-aabce5df2865" = true
+[16608eae-f60f-4a88-800e-aabce5df2865]
+description = "Personal top when there is only one"

--- a/exercises/practice/isbn-verifier/.meta/tests.toml
+++ b/exercises/practice/isbn-verifier/.meta/tests.toml
@@ -1,52 +1,54 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# valid isbn number
-"0caa3eac-d2e3-4c29-8df8-b188bc8c9292" = true
+[0caa3eac-d2e3-4c29-8df8-b188bc8c9292]
+description = "valid isbn number"
 
-# invalid isbn check digit
-"19f76b53-7c24-45f8-87b8-4604d0ccd248" = true
+[19f76b53-7c24-45f8-87b8-4604d0ccd248]
+description = "invalid isbn check digit"
 
-# valid isbn number with a check digit of 10
-"4164bfee-fb0a-4a1c-9f70-64c6a1903dcd" = true
+[4164bfee-fb0a-4a1c-9f70-64c6a1903dcd]
+description = "valid isbn number with a check digit of 10"
 
-# check digit is a character other than X
-"3ed50db1-8982-4423-a993-93174a20825c" = true
+[3ed50db1-8982-4423-a993-93174a20825c]
+description = "check digit is a character other than X"
 
-# invalid character in isbn
-"c19ba0c4-014f-4dc3-a63f-ff9aefc9b5ec" = true
+[c19ba0c4-014f-4dc3-a63f-ff9aefc9b5ec]
+description = "invalid character in isbn"
 
-# X is only valid as a check digit
-"28025280-2c39-4092-9719-f3234b89c627" = true
+[28025280-2c39-4092-9719-f3234b89c627]
+description = "X is only valid as a check digit"
 
-# valid isbn without separating dashes
-"f6294e61-7e79-46b3-977b-f48789a4945b" = true
+[f6294e61-7e79-46b3-977b-f48789a4945b]
+description = "valid isbn without separating dashes"
 
-# isbn without separating dashes and X as check digit
-"185ab99b-3a1b-45f3-aeec-b80d80b07f0b" = true
+[185ab99b-3a1b-45f3-aeec-b80d80b07f0b]
+description = "isbn without separating dashes and X as check digit"
 
-# isbn without check digit and dashes
-"7725a837-ec8e-4528-a92a-d981dd8cf3e2" = true
+[7725a837-ec8e-4528-a92a-d981dd8cf3e2]
+description = "isbn without check digit and dashes"
 
-# too long isbn and no dashes
-"47e4dfba-9c20-46ed-9958-4d3190630bdf" = true
+[47e4dfba-9c20-46ed-9958-4d3190630bdf]
+description = "too long isbn and no dashes"
 
-# too short isbn
-"737f4e91-cbba-4175-95bf-ae630b41fb60" = true
+[737f4e91-cbba-4175-95bf-ae630b41fb60]
+description = "too short isbn"
 
-# isbn without check digit
-"5458a128-a9b6-4ff8-8afb-674e74567cef" = true
+[5458a128-a9b6-4ff8-8afb-674e74567cef]
+description = "isbn without check digit"
 
-# check digit of X should not be used for 0
-"70b6ad83-d0a2-4ca7-a4d5-a9ab731800f7" = true
+[70b6ad83-d0a2-4ca7-a4d5-a9ab731800f7]
+description = "check digit of X should not be used for 0"
 
-# empty isbn
-"94610459-55ab-4c35-9b93-ff6ea1a8e562" = true
+[94610459-55ab-4c35-9b93-ff6ea1a8e562]
+description = "empty isbn"
 
-# input is 9 characters
-"7bff28d4-d770-48cc-80d6-b20b3a0fb46c" = true
+[7bff28d4-d770-48cc-80d6-b20b3a0fb46c]
+description = "input is 9 characters"
 
-# invalid characters are not ignored
-"ed6e8d1b-382c-4081-8326-8b772c581fec" = true
+[ed6e8d1b-382c-4081-8326-8b772c581fec]
+description = "invalid characters are not ignored"
 
-# input is too long but contains a valid isbn
-"fb5e48d8-7c03-4bfb-a088-b101df16fdc3" = true
+[fb5e48d8-7c03-4bfb-a088-b101df16fdc3]
+description = "input is too long but contains a valid isbn"

--- a/exercises/practice/isogram/.meta/tests.toml
+++ b/exercises/practice/isogram/.meta/tests.toml
@@ -1,40 +1,42 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# empty string
-"a0e97d2d-669e-47c7-8134-518a1e2c4555" = true
+[a0e97d2d-669e-47c7-8134-518a1e2c4555]
+description = "empty string"
 
-# isogram with only lower case characters
-"9a001b50-f194-4143-bc29-2af5ec1ef652" = true
+[9a001b50-f194-4143-bc29-2af5ec1ef652]
+description = "isogram with only lower case characters"
 
-# word with one duplicated character
-"8ddb0ca3-276e-4f8b-89da-d95d5bae78a4" = true
+[8ddb0ca3-276e-4f8b-89da-d95d5bae78a4]
+description = "word with one duplicated character"
 
-# word with one duplicated character from the end of the alphabet
-"6450b333-cbc2-4b24-a723-0b459b34fe18" = true
+[6450b333-cbc2-4b24-a723-0b459b34fe18]
+description = "word with one duplicated character from the end of the alphabet"
 
-# longest reported english isogram
-"a15ff557-dd04-4764-99e7-02cc1a385863" = true
+[a15ff557-dd04-4764-99e7-02cc1a385863]
+description = "longest reported english isogram"
 
-# word with duplicated character in mixed case
-"f1a7f6c7-a42f-4915-91d7-35b2ea11c92e" = true
+[f1a7f6c7-a42f-4915-91d7-35b2ea11c92e]
+description = "word with duplicated character in mixed case"
 
-# word with duplicated character in mixed case, lowercase first
-"14a4f3c1-3b47-4695-b645-53d328298942" = true
+[14a4f3c1-3b47-4695-b645-53d328298942]
+description = "word with duplicated character in mixed case, lowercase first"
 
-# hypothetical isogrammic word with hyphen
-"423b850c-7090-4a8a-b057-97f1cadd7c42" = true
+[423b850c-7090-4a8a-b057-97f1cadd7c42]
+description = "hypothetical isogrammic word with hyphen"
 
-# hypothetical word with duplicated character following hyphen
-"93dbeaa0-3c5a-45c2-8b25-428b8eacd4f2" = true
+[93dbeaa0-3c5a-45c2-8b25-428b8eacd4f2]
+description = "hypothetical word with duplicated character following hyphen"
 
-# isogram with duplicated hyphen
-"36b30e5c-173f-49c6-a515-93a3e825553f" = true
+[36b30e5c-173f-49c6-a515-93a3e825553f]
+description = "isogram with duplicated hyphen"
 
-# made-up name that is an isogram
-"cdabafa0-c9f4-4c1f-b142-689c6ee17d93" = true
+[cdabafa0-c9f4-4c1f-b142-689c6ee17d93]
+description = "made-up name that is an isogram"
 
-# duplicated character in the middle
-"5fc61048-d74e-48fd-bc34-abfc21552d4d" = true
+[5fc61048-d74e-48fd-bc34-abfc21552d4d]
+description = "duplicated character in the middle"
 
-# same first and last characters
-"310ac53d-8932-47bc-bbb4-b2b94f25a83e" = true
+[310ac53d-8932-47bc-bbb4-b2b94f25a83e]
+description = "same first and last characters"

--- a/exercises/practice/leap/.meta/tests.toml
+++ b/exercises/practice/leap/.meta/tests.toml
@@ -1,28 +1,30 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# year not divisible by 4 in common year
-"6466b30d-519c-438e-935d-388224ab5223" = true
+[6466b30d-519c-438e-935d-388224ab5223]
+description = "year not divisible by 4 in common year"
 
-# year divisible by 2, not divisible by 4 in common year
-"ac227e82-ee82-4a09-9eb6-4f84331ffdb0" = true
+[ac227e82-ee82-4a09-9eb6-4f84331ffdb0]
+description = "year divisible by 2, not divisible by 4 in common year"
 
-# year divisible by 4, not divisible by 100 in leap year
-"4fe9b84c-8e65-489e-970b-856d60b8b78e" = true
+[4fe9b84c-8e65-489e-970b-856d60b8b78e]
+description = "year divisible by 4, not divisible by 100 in leap year"
 
-# year divisible by 4 and 5 is still a leap year
-"7fc6aed7-e63c-48f5-ae05-5fe182f60a5d" = true
+[7fc6aed7-e63c-48f5-ae05-5fe182f60a5d]
+description = "year divisible by 4 and 5 is still a leap year"
 
-# year divisible by 100, not divisible by 400 in common year
-"78a7848f-9667-4192-ae53-87b30c9a02dd" = true
+[78a7848f-9667-4192-ae53-87b30c9a02dd]
+description = "year divisible by 100, not divisible by 400 in common year"
 
-# year divisible by 100 but not by 3 is still not a leap year
-"9d70f938-537c-40a6-ba19-f50739ce8bac" = true
+[9d70f938-537c-40a6-ba19-f50739ce8bac]
+description = "year divisible by 100 but not by 3 is still not a leap year"
 
-# year divisible by 400 in leap year
-"42ee56ad-d3e6-48f1-8e3f-c84078d916fc" = true
+[42ee56ad-d3e6-48f1-8e3f-c84078d916fc]
+description = "year divisible by 400 in leap year"
 
-# year divisible by 400 but not by 125 is still a leap year
-"57902c77-6fe9-40de-8302-587b5c27121e" = true
+[57902c77-6fe9-40de-8302-587b5c27121e]
+description = "year divisible by 400 but not by 125 is still a leap year"
 
-# year divisible by 200, not divisible by 400 in common year
-"c30331f6-f9f6-4881-ad38-8ca8c12520c1" = true
+[c30331f6-f9f6-4881-ad38-8ca8c12520c1]
+description = "year divisible by 200, not divisible by 400 in common year"

--- a/exercises/practice/luhn/.meta/tests.toml
+++ b/exercises/practice/luhn/.meta/tests.toml
@@ -1,55 +1,57 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# single digit strings can not be valid
-"792a7082-feb7-48c7-b88b-bbfec160865e" = true
+[792a7082-feb7-48c7-b88b-bbfec160865e]
+description = "single digit strings can not be valid"
 
-# a single zero is invalid
-"698a7924-64d4-4d89-8daa-32e1aadc271e" = true
+[698a7924-64d4-4d89-8daa-32e1aadc271e]
+description = "a single zero is invalid"
 
-# a simple valid SIN that remains valid if reversed
-"73c2f62b-9b10-4c9f-9a04-83cee7367965" = true
+[73c2f62b-9b10-4c9f-9a04-83cee7367965]
+description = "a simple valid SIN that remains valid if reversed"
 
-# a simple valid SIN that becomes invalid if reversed
-"9369092e-b095-439f-948d-498bd076be11" = true
+[9369092e-b095-439f-948d-498bd076be11]
+description = "a simple valid SIN that becomes invalid if reversed"
 
-# a valid Canadian SIN
-"8f9f2350-1faf-4008-ba84-85cbb93ffeca" = true
+[8f9f2350-1faf-4008-ba84-85cbb93ffeca]
+description = "a valid Canadian SIN"
 
-# invalid Canadian SIN
-"1cdcf269-6560-44fc-91f6-5819a7548737" = true
+[1cdcf269-6560-44fc-91f6-5819a7548737]
+description = "invalid Canadian SIN"
 
-# invalid credit card
-"656c48c1-34e8-4e60-9a5a-aad8a367810a" = true
+[656c48c1-34e8-4e60-9a5a-aad8a367810a]
+description = "invalid credit card"
 
-# invalid long number with an even remainder
-"20e67fad-2121-43ed-99a8-14b5b856adb9" = true
+[20e67fad-2121-43ed-99a8-14b5b856adb9]
+description = "invalid long number with an even remainder"
 
-# valid number with an even number of digits
-"ad2a0c5f-84ed-4e5b-95da-6011d6f4f0aa" = true
+[ad2a0c5f-84ed-4e5b-95da-6011d6f4f0aa]
+description = "valid number with an even number of digits"
 
-# valid number with an odd number of spaces
-"ef081c06-a41f-4761-8492-385e13c8202d" = true
+[ef081c06-a41f-4761-8492-385e13c8202d]
+description = "valid number with an odd number of spaces"
 
-# valid strings with a non-digit added at the end become invalid
-"bef66f64-6100-4cbb-8f94-4c9713c5e5b2" = true
+[bef66f64-6100-4cbb-8f94-4c9713c5e5b2]
+description = "valid strings with a non-digit added at the end become invalid"
 
-# valid strings with punctuation included become invalid
-"2177e225-9ce7-40f6-b55d-fa420e62938e" = true
+[2177e225-9ce7-40f6-b55d-fa420e62938e]
+description = "valid strings with punctuation included become invalid"
 
-# valid strings with symbols included become invalid
-"ebf04f27-9698-45e1-9afe-7e0851d0fe8d" = true
+[ebf04f27-9698-45e1-9afe-7e0851d0fe8d]
+description = "valid strings with symbols included become invalid"
 
-# single zero with space is invalid
-"08195c5e-ce7f-422c-a5eb-3e45fece68ba" = true
+[08195c5e-ce7f-422c-a5eb-3e45fece68ba]
+description = "single zero with space is invalid"
 
-# more than a single zero is valid
-"12e63a3c-f866-4a79-8c14-b359fc386091" = true
+[12e63a3c-f866-4a79-8c14-b359fc386091]
+description = "more than a single zero is valid"
 
-# input digit 9 is correctly converted to output digit 9
-"ab56fa80-5de8-4735-8a4a-14dae588663e" = true
+[ab56fa80-5de8-4735-8a4a-14dae588663e]
+description = "input digit 9 is correctly converted to output digit 9"
 
-# using ascii value for non-doubled non-digit isn't allowed
-"39a06a5a-5bad-4e0f-b215-b042d46209b1" = true
+[39a06a5a-5bad-4e0f-b215-b042d46209b1]
+description = "using ascii value for non-doubled non-digit isn't allowed"
 
-# using ascii value for doubled non-digit isn't allowed
-"f94cf191-a62f-4868-bc72-7253114aa157" = true
+[f94cf191-a62f-4868-bc72-7253114aa157]
+description = "using ascii value for doubled non-digit isn't allowed"

--- a/exercises/practice/matching-brackets/.meta/tests.toml
+++ b/exercises/practice/matching-brackets/.meta/tests.toml
@@ -1,52 +1,54 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# paired square brackets
-"81ec11da-38dd-442a-bcf9-3de7754609a5" = true
+[81ec11da-38dd-442a-bcf9-3de7754609a5]
+description = "paired square brackets"
 
-# empty string
-"287f0167-ac60-4b64-8452-a0aa8f4e5238" = true
+[287f0167-ac60-4b64-8452-a0aa8f4e5238]
+description = "empty string"
 
-# unpaired brackets
-"6c3615a3-df01-4130-a731-8ef5f5d78dac" = true
+[6c3615a3-df01-4130-a731-8ef5f5d78dac]
+description = "unpaired brackets"
 
-# wrong ordered brackets
-"9d414171-9b98-4cac-a4e5-941039a97a77" = true
+[9d414171-9b98-4cac-a4e5-941039a97a77]
+description = "wrong ordered brackets"
 
-# wrong closing bracket
-"f0f97c94-a149-4736-bc61-f2c5148ffb85" = true
+[f0f97c94-a149-4736-bc61-f2c5148ffb85]
+description = "wrong closing bracket"
 
-# paired with whitespace
-"754468e0-4696-4582-a30e-534d47d69756" = true
+[754468e0-4696-4582-a30e-534d47d69756]
+description = "paired with whitespace"
 
-# partially paired brackets
-"ba84f6ee-8164-434a-9c3e-b02c7f8e8545" = true
+[ba84f6ee-8164-434a-9c3e-b02c7f8e8545]
+description = "partially paired brackets"
 
-# simple nested brackets
-"3c86c897-5ff3-4a2b-ad9b-47ac3a30651d" = true
+[3c86c897-5ff3-4a2b-ad9b-47ac3a30651d]
+description = "simple nested brackets"
 
-# several paired brackets
-"2d137f2c-a19e-4993-9830-83967a2d4726" = true
+[2d137f2c-a19e-4993-9830-83967a2d4726]
+description = "several paired brackets"
 
-# paired and nested brackets
-"2e1f7b56-c137-4c92-9781-958638885a44" = true
+[2e1f7b56-c137-4c92-9781-958638885a44]
+description = "paired and nested brackets"
 
-# unopened closing brackets
-"84f6233b-e0f7-4077-8966-8085d295c19b" = true
+[84f6233b-e0f7-4077-8966-8085d295c19b]
+description = "unopened closing brackets"
 
-# unpaired and nested brackets
-"9b18c67d-7595-4982-b2c5-4cb949745d49" = true
+[9b18c67d-7595-4982-b2c5-4cb949745d49]
+description = "unpaired and nested brackets"
 
-# paired and wrong nested brackets
-"a0205e34-c2ac-49e6-a88a-899508d7d68e" = true
+[a0205e34-c2ac-49e6-a88a-899508d7d68e]
+description = "paired and wrong nested brackets"
 
-# paired and incomplete brackets
-"ef47c21b-bcfd-4998-844c-7ad5daad90a8" = true
+[ef47c21b-bcfd-4998-844c-7ad5daad90a8]
+description = "paired and incomplete brackets"
 
-# too many closing brackets
-"a4675a40-a8be-4fc2-bc47-2a282ce6edbe" = true
+[a4675a40-a8be-4fc2-bc47-2a282ce6edbe]
+description = "too many closing brackets"
 
-# math expression
-"99255f93-261b-4435-a352-02bdecc9bdf2" = true
+[99255f93-261b-4435-a352-02bdecc9bdf2]
+description = "math expression"
 
-# complex latex expression
-"8e357d79-f302-469a-8515-2561877256a1" = true
+[8e357d79-f302-469a-8515-2561877256a1]
+description = "complex latex expression"

--- a/exercises/practice/matrix/.meta/tests.toml
+++ b/exercises/practice/matrix/.meta/tests.toml
@@ -1,25 +1,27 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# extract row from one number matrix
-"ca733dab-9d85-4065-9ef6-a880a951dafd" = true
+[ca733dab-9d85-4065-9ef6-a880a951dafd]
+description = "extract row from one number matrix"
 
-# can extract row
-"5c93ec93-80e1-4268-9fc2-63bc7d23385c" = true
+[5c93ec93-80e1-4268-9fc2-63bc7d23385c]
+description = "can extract row"
 
-# extract row where numbers have different widths
-"2f1aad89-ad0f-4bd2-9919-99a8bff0305a" = true
+[2f1aad89-ad0f-4bd2-9919-99a8bff0305a]
+description = "extract row where numbers have different widths"
 
-# can extract row from non-square matrix with no corresponding column
-"68f7f6ba-57e2-4e87-82d0-ad09889b5204" = true
+[68f7f6ba-57e2-4e87-82d0-ad09889b5204]
+description = "can extract row from non-square matrix with no corresponding column"
 
-# extract column from one number matrix
-"e8c74391-c93b-4aed-8bfe-f3c9beb89ebb" = true
+[e8c74391-c93b-4aed-8bfe-f3c9beb89ebb]
+description = "extract column from one number matrix"
 
-# can extract column
-"7136bdbd-b3dc-48c4-a10c-8230976d3727" = true
+[7136bdbd-b3dc-48c4-a10c-8230976d3727]
+description = "can extract column"
 
-# can extract column from non-square matrix with no corresponding row
-"ad64f8d7-bba6-4182-8adf-0c14de3d0eca" = true
+[ad64f8d7-bba6-4182-8adf-0c14de3d0eca]
+description = "can extract column from non-square matrix with no corresponding row"
 
-# extract column where numbers have different widths
-"9eddfa5c-8474-440e-ae0a-f018c2a0dd89" = true
+[9eddfa5c-8474-440e-ae0a-f018c2a0dd89]
+description = "extract column where numbers have different widths"

--- a/exercises/practice/minesweeper/.meta/tests.toml
+++ b/exercises/practice/minesweeper/.meta/tests.toml
@@ -1,37 +1,39 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# no rows
-"0c5ec4bd-dea7-4138-8651-1203e1cb9f44" = true
+[0c5ec4bd-dea7-4138-8651-1203e1cb9f44]
+description = "no rows"
 
-# no columns
-"650ac4c0-ad6b-4b41-acde-e4ea5852c3b8" = true
+[650ac4c0-ad6b-4b41-acde-e4ea5852c3b8]
+description = "no columns"
 
-# no mines
-"6fbf8f6d-a03b-42c9-9a58-b489e9235478" = true
+[6fbf8f6d-a03b-42c9-9a58-b489e9235478]
+description = "no mines"
 
-# minefield with only mines
-"61aff1c4-fb31-4078-acad-cd5f1e635655" = true
+[61aff1c4-fb31-4078-acad-cd5f1e635655]
+description = "minefield with only mines"
 
-# mine surrounded by spaces
-"84167147-c504-4896-85d7-246b01dea7c5" = true
+[84167147-c504-4896-85d7-246b01dea7c5]
+description = "mine surrounded by spaces"
 
-# space surrounded by mines
-"cb878f35-43e3-4c9d-93d9-139012cccc4a" = true
+[cb878f35-43e3-4c9d-93d9-139012cccc4a]
+description = "space surrounded by mines"
 
-# horizontal line
-"7037f483-ddb4-4b35-b005-0d0f4ef4606f" = true
+[7037f483-ddb4-4b35-b005-0d0f4ef4606f]
+description = "horizontal line"
 
-# horizontal line, mines at edges
-"e359820f-bb8b-4eda-8762-47b64dba30a6" = true
+[e359820f-bb8b-4eda-8762-47b64dba30a6]
+description = "horizontal line, mines at edges"
 
-# vertical line
-"c5198b50-804f-47e9-ae02-c3b42f7ce3ab" = true
+[c5198b50-804f-47e9-ae02-c3b42f7ce3ab]
+description = "vertical line"
 
-# vertical line, mines at edges
-"0c79a64d-703d-4660-9e90-5adfa5408939" = true
+[0c79a64d-703d-4660-9e90-5adfa5408939]
+description = "vertical line, mines at edges"
 
-# cross
-"4b098563-b7f3-401c-97c6-79dd1b708f34" = true
+[4b098563-b7f3-401c-97c6-79dd1b708f34]
+description = "cross"
 
-# large minefield
-"04a260f1-b40a-4e89-839e-8dd8525abe0e" = true
+[04a260f1-b40a-4e89-839e-8dd8525abe0e]
+description = "large minefield"

--- a/exercises/practice/pangram/.meta/tests.toml
+++ b/exercises/practice/pangram/.meta/tests.toml
@@ -1,31 +1,33 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# empty sentence
-"64f61791-508e-4f5c-83ab-05de042b0149" = true
+[64f61791-508e-4f5c-83ab-05de042b0149]
+description = "empty sentence"
 
-# perfect lower case
-"74858f80-4a4d-478b-8a5e-c6477e4e4e84" = true
+[74858f80-4a4d-478b-8a5e-c6477e4e4e84]
+description = "perfect lower case"
 
-# only lower case
-"61288860-35ca-4abe-ba08-f5df76ecbdcd" = true
+[61288860-35ca-4abe-ba08-f5df76ecbdcd]
+description = "only lower case"
 
-# missing the letter 'x'
-"6564267d-8ac5-4d29-baf2-e7d2e304a743" = true
+[6564267d-8ac5-4d29-baf2-e7d2e304a743]
+description = "missing the letter 'x'"
 
-# missing the letter 'h'
-"c79af1be-d715-4cdb-a5f2-b2fa3e7e0de0" = true
+[c79af1be-d715-4cdb-a5f2-b2fa3e7e0de0]
+description = "missing the letter 'h'"
 
-# with underscores
-"d835ec38-bc8f-48e4-9e36-eb232427b1df" = true
+[d835ec38-bc8f-48e4-9e36-eb232427b1df]
+description = "with underscores"
 
-# with numbers
-"8cc1e080-a178-4494-b4b3-06982c9be2a8" = true
+[8cc1e080-a178-4494-b4b3-06982c9be2a8]
+description = "with numbers"
 
-# missing letters replaced by numbers
-"bed96b1c-ff95-45b8-9731-fdbdcb6ede9a" = true
+[bed96b1c-ff95-45b8-9731-fdbdcb6ede9a]
+description = "missing letters replaced by numbers"
 
-# mixed case and punctuation
-"938bd5d8-ade5-40e2-a2d9-55a338a01030" = true
+[938bd5d8-ade5-40e2-a2d9-55a338a01030]
+description = "mixed case and punctuation"
 
-# case insensitive
-"2577bf54-83c8-402d-a64b-a2c0f7bb213a" = true
+[2577bf54-83c8-402d-a64b-a2c0f7bb213a]
+description = "case insensitive"

--- a/exercises/practice/proverb/.meta/tests.toml
+++ b/exercises/practice/proverb/.meta/tests.toml
@@ -1,19 +1,21 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# zero pieces
-"e974b73e-7851-484f-8d6d-92e07fe742fc" = true
+[e974b73e-7851-484f-8d6d-92e07fe742fc]
+description = "zero pieces"
 
-# one piece
-"2fcd5f5e-8b82-4e74-b51d-df28a5e0faa4" = true
+[2fcd5f5e-8b82-4e74-b51d-df28a5e0faa4]
+description = "one piece"
 
-# two pieces
-"d9d0a8a1-d933-46e2-aa94-eecf679f4b0e" = true
+[d9d0a8a1-d933-46e2-aa94-eecf679f4b0e]
+description = "two pieces"
 
-# three pieces
-"c95ef757-5e94-4f0d-a6cb-d2083f5e5a83" = true
+[c95ef757-5e94-4f0d-a6cb-d2083f5e5a83]
+description = "three pieces"
 
-# full proverb
-"433fb91c-35a2-4d41-aeab-4de1e82b2126" = true
+[433fb91c-35a2-4d41-aeab-4de1e82b2126]
+description = "full proverb"
 
-# four pieces modernized
-"c1eefa5a-e8d9-41c7-91d4-99fab6d6b9f7" = true
+[c1eefa5a-e8d9-41c7-91d4-99fab6d6b9f7]
+description = "four pieces modernized"

--- a/exercises/practice/raindrops/.meta/tests.toml
+++ b/exercises/practice/raindrops/.meta/tests.toml
@@ -1,55 +1,57 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# the sound for 1 is 1
-"1575d549-e502-46d4-a8e1-6b7bec6123d8" = true
+[1575d549-e502-46d4-a8e1-6b7bec6123d8]
+description = "the sound for 1 is 1"
 
-# the sound for 3 is Pling
-"1f51a9f9-4895-4539-b182-d7b0a5ab2913" = true
+[1f51a9f9-4895-4539-b182-d7b0a5ab2913]
+description = "the sound for 3 is Pling"
 
-# the sound for 5 is Plang
-"2d9bfae5-2b21-4bcd-9629-c8c0e388f3e0" = true
+[2d9bfae5-2b21-4bcd-9629-c8c0e388f3e0]
+description = "the sound for 5 is Plang"
 
-# the sound for 7 is Plong
-"d7e60daa-32ef-4c23-b688-2abff46c4806" = true
+[d7e60daa-32ef-4c23-b688-2abff46c4806]
+description = "the sound for 7 is Plong"
 
-# the sound for 6 is Pling as it has a factor 3
-"6bb4947b-a724-430c-923f-f0dc3d62e56a" = true
+[6bb4947b-a724-430c-923f-f0dc3d62e56a]
+description = "the sound for 6 is Pling as it has a factor 3"
 
-# 2 to the power 3 does not make a raindrop sound as 3 is the exponent not the base
-"ce51e0e8-d9d4-446d-9949-96eac4458c2d" = true
+[ce51e0e8-d9d4-446d-9949-96eac4458c2d]
+description = "2 to the power 3 does not make a raindrop sound as 3 is the exponent not the base"
 
-# the sound for 9 is Pling as it has a factor 3
-"0dd66175-e3e2-47fc-8750-d01739856671" = true
+[0dd66175-e3e2-47fc-8750-d01739856671]
+description = "the sound for 9 is Pling as it has a factor 3"
 
-# the sound for 10 is Plang as it has a factor 5
-"022c44d3-2182-4471-95d7-c575af225c96" = true
+[022c44d3-2182-4471-95d7-c575af225c96]
+description = "the sound for 10 is Plang as it has a factor 5"
 
-# the sound for 14 is Plong as it has a factor of 7
-"37ab74db-fed3-40ff-b7b9-04acdfea8edf" = true
+[37ab74db-fed3-40ff-b7b9-04acdfea8edf]
+description = "the sound for 14 is Plong as it has a factor of 7"
 
-# the sound for 15 is PlingPlang as it has factors 3 and 5
-"31f92999-6afb-40ee-9aa4-6d15e3334d0f" = true
+[31f92999-6afb-40ee-9aa4-6d15e3334d0f]
+description = "the sound for 15 is PlingPlang as it has factors 3 and 5"
 
-# the sound for 21 is PlingPlong as it has factors 3 and 7
-"ff9bb95d-6361-4602-be2c-653fe5239b54" = true
+[ff9bb95d-6361-4602-be2c-653fe5239b54]
+description = "the sound for 21 is PlingPlong as it has factors 3 and 7"
 
-# the sound for 25 is Plang as it has a factor 5
-"d2e75317-b72e-40ab-8a64-6734a21dece1" = true
+[d2e75317-b72e-40ab-8a64-6734a21dece1]
+description = "the sound for 25 is Plang as it has a factor 5"
 
-# the sound for 27 is Pling as it has a factor 3
-"a09c4c58-c662-4e32-97fe-f1501ef7125c" = true
+[a09c4c58-c662-4e32-97fe-f1501ef7125c]
+description = "the sound for 27 is Pling as it has a factor 3"
 
-# the sound for 35 is PlangPlong as it has factors 5 and 7
-"bdf061de-8564-4899-a843-14b48b722789" = true
+[bdf061de-8564-4899-a843-14b48b722789]
+description = "the sound for 35 is PlangPlong as it has factors 5 and 7"
 
-# the sound for 49 is Plong as it has a factor 7
-"c4680bee-69ba-439d-99b5-70c5fd1a7a83" = true
+[c4680bee-69ba-439d-99b5-70c5fd1a7a83]
+description = "the sound for 49 is Plong as it has a factor 7"
 
-# the sound for 52 is 52
-"17f2bc9a-b65a-4d23-8ccd-266e8c271444" = true
+[17f2bc9a-b65a-4d23-8ccd-266e8c271444]
+description = "the sound for 52 is 52"
 
-# the sound for 105 is PlingPlangPlong as it has factors 3, 5 and 7
-"e46677ed-ff1a-419f-a740-5c713d2830e4" = true
+[e46677ed-ff1a-419f-a740-5c713d2830e4]
+description = "the sound for 105 is PlingPlangPlong as it has factors 3, 5 and 7"
 
-# the sound for 3125 is Plang as it has a factor 5
-"13c6837a-0fcd-4b86-a0eb-20572f7deb0b" = true
+[13c6837a-0fcd-4b86-a0eb-20572f7deb0b]
+description = "the sound for 3125 is Plang as it has a factor 5"

--- a/exercises/practice/resistor-color-duo/.meta/tests.toml
+++ b/exercises/practice/resistor-color-duo/.meta/tests.toml
@@ -1,16 +1,18 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# Brown and black
-"ce11995a-5b93-4950-a5e9-93423693b2fc" = true
+[ce11995a-5b93-4950-a5e9-93423693b2fc]
+description = "Brown and black"
 
-# Blue and grey
-"7bf82f7a-af23-48ba-a97d-38d59406a920" = true
+[7bf82f7a-af23-48ba-a97d-38d59406a920]
+description = "Blue and grey"
 
-# Yellow and violet
-"f1886361-fdfd-4693-acf8-46726fe24e0c" = true
+[f1886361-fdfd-4693-acf8-46726fe24e0c]
+description = "Yellow and violet"
 
-# Orange and orange
-"77a8293d-2a83-4016-b1af-991acc12b9fe" = true
+[77a8293d-2a83-4016-b1af-991acc12b9fe]
+description = "Orange and orange"
 
-# Ignore additional colors
-"0c4fb44f-db7c-4d03-afa8-054350f156a8" = true
+[0c4fb44f-db7c-4d03-afa8-054350f156a8]
+description = "Ignore additional colors"

--- a/exercises/practice/reverse-string/.meta/tests.toml
+++ b/exercises/practice/reverse-string/.meta/tests.toml
@@ -1,19 +1,21 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# an empty string
-"c3b7d806-dced-49ee-8543-933fd1719b1c" = true
+[c3b7d806-dced-49ee-8543-933fd1719b1c]
+description = "an empty string"
 
-# a word
-"01ebf55b-bebb-414e-9dec-06f7bb0bee3c" = true
+[01ebf55b-bebb-414e-9dec-06f7bb0bee3c]
+description = "a word"
 
-# a capitalized word
-"0f7c07e4-efd1-4aaa-a07a-90b49ce0b746" = true
+[0f7c07e4-efd1-4aaa-a07a-90b49ce0b746]
+description = "a capitalized word"
 
-# a sentence with punctuation
-"71854b9c-f200-4469-9f5c-1e8e5eff5614" = true
+[71854b9c-f200-4469-9f5c-1e8e5eff5614]
+description = "a sentence with punctuation"
 
-# a palindrome
-"1f8ed2f3-56f3-459b-8f3e-6d8d654a1f6c" = true
+[1f8ed2f3-56f3-459b-8f3e-6d8d654a1f6c]
+description = "a palindrome"
 
-# an even-sized word
-"b9e7dec1-c6df-40bd-9fa3-cd7ded010c4c" = true
+[b9e7dec1-c6df-40bd-9fa3-cd7ded010c4c]
+description = "an even-sized word"

--- a/exercises/practice/robot-simulator/.meta/tests.toml
+++ b/exercises/practice/robot-simulator/.meta/tests.toml
@@ -1,55 +1,57 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# at origin facing north
-"c557c16d-26c1-4e06-827c-f6602cd0785c" = true
+[c557c16d-26c1-4e06-827c-f6602cd0785c]
+description = "at origin facing north"
 
-# at negative position facing south
-"bf0dffce-f11c-4cdb-8a5e-2c89d8a5a67d" = true
+[bf0dffce-f11c-4cdb-8a5e-2c89d8a5a67d]
+description = "at negative position facing south"
 
-# changes north to east
-"8cbd0086-6392-4680-b9b9-73cf491e67e5" = true
+[8cbd0086-6392-4680-b9b9-73cf491e67e5]
+description = "changes north to east"
 
-# changes east to south
-"8abc87fc-eab2-4276-93b7-9c009e866ba1" = true
+[8abc87fc-eab2-4276-93b7-9c009e866ba1]
+description = "changes east to south"
 
-# changes south to west
-"3cfe1b85-bbf2-4bae-b54d-d73e7e93617a" = true
+[3cfe1b85-bbf2-4bae-b54d-d73e7e93617a]
+description = "changes south to west"
 
-# changes west to north
-"5ea9fb99-3f2c-47bd-86f7-46b7d8c3c716" = true
+[5ea9fb99-3f2c-47bd-86f7-46b7d8c3c716]
+description = "changes west to north"
 
-# changes north to west
-"fa0c40f5-6ba3-443d-a4b3-58cbd6cb8d63" = true
+[fa0c40f5-6ba3-443d-a4b3-58cbd6cb8d63]
+description = "changes north to west"
 
-# changes west to south
-"da33d734-831f-445c-9907-d66d7d2a92e2" = true
+[da33d734-831f-445c-9907-d66d7d2a92e2]
+description = "changes west to south"
 
-# changes south to east
-"bd1ca4b9-4548-45f4-b32e-900fc7c19389" = true
+[bd1ca4b9-4548-45f4-b32e-900fc7c19389]
+description = "changes south to east"
 
-# changes east to north
-"2de27b67-a25c-4b59-9883-bc03b1b55bba" = true
+[2de27b67-a25c-4b59-9883-bc03b1b55bba]
+description = "changes east to north"
 
-# facing north increments Y
-"f0dc2388-cddc-4f83-9bed-bcf46b8fc7b8" = true
+[f0dc2388-cddc-4f83-9bed-bcf46b8fc7b8]
+description = "facing north increments Y"
 
-# facing south decrements Y
-"2786cf80-5bbf-44b0-9503-a89a9c5789da" = true
+[2786cf80-5bbf-44b0-9503-a89a9c5789da]
+description = "facing south decrements Y"
 
-# facing east increments X
-"84bf3c8c-241f-434d-883d-69817dbd6a48" = true
+[84bf3c8c-241f-434d-883d-69817dbd6a48]
+description = "facing east increments X"
 
-# facing west decrements X
-"bb69c4a7-3bbf-4f64-b415-666fa72d7b04" = true
+[bb69c4a7-3bbf-4f64-b415-666fa72d7b04]
+description = "facing west decrements X"
 
-# moving east and north from README
-"e34ac672-4ed4-4be3-a0b8-d9af259cbaa1" = true
+[e34ac672-4ed4-4be3-a0b8-d9af259cbaa1]
+description = "moving east and north from README"
 
-# moving west and north
-"f30e4955-4b47-4aa3-8b39-ae98cfbd515b" = true
+[f30e4955-4b47-4aa3-8b39-ae98cfbd515b]
+description = "moving west and north"
 
-# moving west and south
-"3e466bf6-20ab-4d79-8b51-264165182fca" = true
+[3e466bf6-20ab-4d79-8b51-264165182fca]
+description = "moving west and south"
 
-# moving east and north
-"41f0bb96-c617-4e6b-acff-a4b279d44514" = true
+[41f0bb96-c617-4e6b-acff-a4b279d44514]
+description = "moving east and north"

--- a/exercises/practice/roman-numerals/.meta/tests.toml
+++ b/exercises/practice/roman-numerals/.meta/tests.toml
@@ -1,58 +1,60 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# 1 is a single I
-"19828a3a-fbf7-4661-8ddd-cbaeee0e2178" = true
+[19828a3a-fbf7-4661-8ddd-cbaeee0e2178]
+description = "1 is a single I"
 
-# 2 is two I's
-"f088f064-2d35-4476-9a41-f576da3f7b03" = true
+[f088f064-2d35-4476-9a41-f576da3f7b03]
+description = "2 is two I's"
 
-# 3 is three I's
-"b374a79c-3bea-43e6-8db8-1286f79c7106" = true
+[b374a79c-3bea-43e6-8db8-1286f79c7106]
+description = "3 is three I's"
 
-# 4, being 5 - 1, is IV
-"05a0a1d4-a140-4db1-82e8-fcc21fdb49bb" = true
+[05a0a1d4-a140-4db1-82e8-fcc21fdb49bb]
+description = "4, being 5 - 1, is IV"
 
-# 5 is a single V
-"57c0f9ad-5024-46ab-975d-de18c430b290" = true
+[57c0f9ad-5024-46ab-975d-de18c430b290]
+description = "5 is a single V"
 
-# 6, being 5 + 1, is VI
-"20a2b47f-e57f-4797-a541-0b3825d7f249" = true
+[20a2b47f-e57f-4797-a541-0b3825d7f249]
+description = "6, being 5 + 1, is VI"
 
-# 9, being 10 - 1, is IX
-"ff3fb08c-4917-4aab-9f4e-d663491d083d" = true
+[ff3fb08c-4917-4aab-9f4e-d663491d083d]
+description = "9, being 10 - 1, is IX"
 
-# 20 is two X's
-"2bda64ca-7d28-4c56-b08d-16ce65716cf6" = true
+[2bda64ca-7d28-4c56-b08d-16ce65716cf6]
+description = "20 is two X's"
 
-# 48 is not 50 - 2 but rather 40 + 8
-"a1f812ef-84da-4e02-b4f0-89c907d0962c" = true
+[a1f812ef-84da-4e02-b4f0-89c907d0962c]
+description = "48 is not 50 - 2 but rather 40 + 8"
 
-# 49 is not 40 + 5 + 4 but rather 50 - 10 + 10 - 1
-"607ead62-23d6-4c11-a396-ef821e2e5f75" = true
+[607ead62-23d6-4c11-a396-ef821e2e5f75]
+description = "49 is not 40 + 5 + 4 but rather 50 - 10 + 10 - 1"
 
-# 50 is a single L
-"d5b283d4-455d-4e68-aacf-add6c4b51915" = true
+[d5b283d4-455d-4e68-aacf-add6c4b51915]
+description = "50 is a single L"
 
-# 90, being 100 - 10, is XC
-"46b46e5b-24da-4180-bfe2-2ef30b39d0d0" = true
+[46b46e5b-24da-4180-bfe2-2ef30b39d0d0]
+description = "90, being 100 - 10, is XC"
 
-# 100 is a single C
-"30494be1-9afb-4f84-9d71-db9df18b55e3" = true
+[30494be1-9afb-4f84-9d71-db9df18b55e3]
+description = "100 is a single C"
 
-# 60, being 50 + 10, is LX
-"267f0207-3c55-459a-b81d-67cec7a46ed9" = true
+[267f0207-3c55-459a-b81d-67cec7a46ed9]
+description = "60, being 50 + 10, is LX"
 
-# 400, being 500 - 100, is CD
-"cdb06885-4485-4d71-8bfb-c9d0f496b404" = true
+[cdb06885-4485-4d71-8bfb-c9d0f496b404]
+description = "400, being 500 - 100, is CD"
 
-# 500 is a single D
-"6b71841d-13b2-46b4-ba97-dec28133ea80" = true
+[6b71841d-13b2-46b4-ba97-dec28133ea80]
+description = "500 is a single D"
 
-# 900, being 1000 - 100, is CM
-"432de891-7fd6-4748-a7f6-156082eeca2f" = true
+[432de891-7fd6-4748-a7f6-156082eeca2f]
+description = "900, being 1000 - 100, is CM"
 
-# 1000 is a single M
-"e6de6d24-f668-41c0-88d7-889c0254d173" = true
+[e6de6d24-f668-41c0-88d7-889c0254d173]
+description = "1000 is a single M"
 
-# 3000 is three M's
-"bb550038-d4eb-4be2-a9ce-f21961ac3bc6" = true
+[bb550038-d4eb-4be2-a9ce-f21961ac3bc6]
+description = "3000 is three M's"

--- a/exercises/practice/secret-handshake/.meta/tests.toml
+++ b/exercises/practice/secret-handshake/.meta/tests.toml
@@ -1,34 +1,36 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# wink for 1
-"b8496fbd-6778-468c-8054-648d03c4bb23" = true
+[b8496fbd-6778-468c-8054-648d03c4bb23]
+description = "wink for 1"
 
-# double blink for 10
-"83ec6c58-81a9-4fd1-bfaf-0160514fc0e3" = true
+[83ec6c58-81a9-4fd1-bfaf-0160514fc0e3]
+description = "double blink for 10"
 
-# close your eyes for 100
-"0e20e466-3519-4134-8082-5639d85fef71" = true
+[0e20e466-3519-4134-8082-5639d85fef71]
+description = "close your eyes for 100"
 
-# jump for 1000
-"b339ddbb-88b7-4b7d-9b19-4134030d9ac0" = true
+[b339ddbb-88b7-4b7d-9b19-4134030d9ac0]
+description = "jump for 1000"
 
-# combine two actions
-"40499fb4-e60c-43d7-8b98-0de3ca44e0eb" = true
+[40499fb4-e60c-43d7-8b98-0de3ca44e0eb]
+description = "combine two actions"
 
-# reverse two actions
-"9730cdd5-ef27-494b-afd3-5c91ad6c3d9d" = true
+[9730cdd5-ef27-494b-afd3-5c91ad6c3d9d]
+description = "reverse two actions"
 
-# reversing one action gives the same action
-"0b828205-51ca-45cd-90d5-f2506013f25f" = true
+[0b828205-51ca-45cd-90d5-f2506013f25f]
+description = "reversing one action gives the same action"
 
-# reversing no actions still gives no actions
-"9949e2ac-6c9c-4330-b685-2089ab28b05f" = true
+[9949e2ac-6c9c-4330-b685-2089ab28b05f]
+description = "reversing no actions still gives no actions"
 
-# all possible actions
-"23fdca98-676b-4848-970d-cfed7be39f81" = true
+[23fdca98-676b-4848-970d-cfed7be39f81]
+description = "all possible actions"
 
-# reverse all possible actions
-"ae8fe006-d910-4d6f-be00-54b7c3799e79" = true
+[ae8fe006-d910-4d6f-be00-54b7c3799e79]
+description = "reverse all possible actions"
 
-# do nothing for zero
-"3d36da37-b31f-4cdb-a396-d93a2ee1c4a5" = true
+[3d36da37-b31f-4cdb-a396-d93a2ee1c4a5]
+description = "do nothing for zero"

--- a/exercises/practice/sieve/.meta/tests.toml
+++ b/exercises/practice/sieve/.meta/tests.toml
@@ -1,16 +1,18 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# no primes under two
-"88529125-c4ce-43cc-bb36-1eb4ddd7b44f" = true
+[88529125-c4ce-43cc-bb36-1eb4ddd7b44f]
+description = "no primes under two"
 
-# find first prime
-"4afe9474-c705-4477-9923-840e1024cc2b" = true
+[4afe9474-c705-4477-9923-840e1024cc2b]
+description = "find first prime"
 
-# find primes up to 10
-"974945d8-8cd9-4f00-9463-7d813c7f17b7" = true
+[974945d8-8cd9-4f00-9463-7d813c7f17b7]
+description = "find primes up to 10"
 
-# limit is prime
-"2e2417b7-3f3a-452a-8594-b9af08af6d82" = true
+[2e2417b7-3f3a-452a-8594-b9af08af6d82]
+description = "limit is prime"
 
-# find primes up to 1000
-"92102a05-4c7c-47de-9ed0-b7d5fcd00f21" = true
+[92102a05-4c7c-47de-9ed0-b7d5fcd00f21]
+description = "find primes up to 1000"

--- a/exercises/practice/space-age/.meta/tests.toml
+++ b/exercises/practice/space-age/.meta/tests.toml
@@ -1,25 +1,27 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# age on Earth
-"84f609af-5a91-4d68-90a3-9e32d8a5cd34" = true
+[84f609af-5a91-4d68-90a3-9e32d8a5cd34]
+description = "age on Earth"
 
-# age on Mercury
-"ca20c4e9-6054-458c-9312-79679ffab40b" = true
+[ca20c4e9-6054-458c-9312-79679ffab40b]
+description = "age on Mercury"
 
-# age on Venus
-"502c6529-fd1b-41d3-8fab-65e03082b024" = true
+[502c6529-fd1b-41d3-8fab-65e03082b024]
+description = "age on Venus"
 
-# age on Mars
-"9ceadf5e-a0d5-4388-9d40-2c459227ceb8" = true
+[9ceadf5e-a0d5-4388-9d40-2c459227ceb8]
+description = "age on Mars"
 
-# age on Jupiter
-"42927dc3-fe5e-4f76-a5b5-f737fc19bcde" = true
+[42927dc3-fe5e-4f76-a5b5-f737fc19bcde]
+description = "age on Jupiter"
 
-# age on Saturn
-"8469b332-7837-4ada-b27c-00ee043ebcad" = true
+[8469b332-7837-4ada-b27c-00ee043ebcad]
+description = "age on Saturn"
 
-# age on Uranus
-"999354c1-76f8-4bb5-a672-f317b6436743" = true
+[999354c1-76f8-4bb5-a672-f317b6436743]
+description = "age on Uranus"
 
-# age on Neptune
-"80096d30-a0d4-4449-903e-a381178355d8" = true
+[80096d30-a0d4-4449-903e-a381178355d8]
+description = "age on Neptune"

--- a/exercises/practice/sum-of-multiples/.meta/tests.toml
+++ b/exercises/practice/sum-of-multiples/.meta/tests.toml
@@ -1,49 +1,51 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# no multiples within limit
-"54aaab5a-ce86-4edc-8b40-d3ab2400a279" = true
+[54aaab5a-ce86-4edc-8b40-d3ab2400a279]
+description = "no multiples within limit"
 
-# one factor has multiples within limit
-"361e4e50-c89b-4f60-95ef-5bc5c595490a" = true
+[361e4e50-c89b-4f60-95ef-5bc5c595490a]
+description = "one factor has multiples within limit"
 
-# more than one multiple within limit
-"e644e070-040e-4ae0-9910-93c69fc3f7ce" = true
+[e644e070-040e-4ae0-9910-93c69fc3f7ce]
+description = "more than one multiple within limit"
 
-# more than one factor with multiples within limit
-"607d6eb9-535c-41ce-91b5-3a61da3fa57f" = true
+[607d6eb9-535c-41ce-91b5-3a61da3fa57f]
+description = "more than one factor with multiples within limit"
 
-# each multiple is only counted once
-"f47e8209-c0c5-4786-b07b-dc273bf86b9b" = true
+[f47e8209-c0c5-4786-b07b-dc273bf86b9b]
+description = "each multiple is only counted once"
 
-# a much larger limit
-"28c4b267-c980-4054-93e9-07723db615ac" = true
+[28c4b267-c980-4054-93e9-07723db615ac]
+description = "a much larger limit"
 
-# three factors
-"09c4494d-ff2d-4e0f-8421-f5532821ee12" = true
+[09c4494d-ff2d-4e0f-8421-f5532821ee12]
+description = "three factors"
 
-# factors not relatively prime
-"2d0d5faa-f177-4ad6-bde9-ebb865083751" = true
+[2d0d5faa-f177-4ad6-bde9-ebb865083751]
+description = "factors not relatively prime"
 
-# some pairs of factors relatively prime and some not
-"ece8f2e8-96aa-4166-bbb7-6ce71261e354" = true
+[ece8f2e8-96aa-4166-bbb7-6ce71261e354]
+description = "some pairs of factors relatively prime and some not"
 
-# one factor is a multiple of another
-"624fdade-6ffb-400e-8472-456a38c171c0" = true
+[624fdade-6ffb-400e-8472-456a38c171c0]
+description = "one factor is a multiple of another"
 
-# much larger factors
-"949ee7eb-db51-479c-b5cb-4a22b40ac057" = true
+[949ee7eb-db51-479c-b5cb-4a22b40ac057]
+description = "much larger factors"
 
-# all numbers are multiples of 1
-"41093673-acbd-482c-ab80-d00a0cbedecd" = true
+[41093673-acbd-482c-ab80-d00a0cbedecd]
+description = "all numbers are multiples of 1"
 
-# no factors means an empty sum
-"1730453b-baaa-438e-a9c2-d754497b2a76" = true
+[1730453b-baaa-438e-a9c2-d754497b2a76]
+description = "no factors means an empty sum"
 
-# the only multiple of 0 is 0
-"214a01e9-f4bf-45bb-80f1-1dce9fbb0310" = true
+[214a01e9-f4bf-45bb-80f1-1dce9fbb0310]
+description = "the only multiple of 0 is 0"
 
-# the factor 0 does not affect the sum of multiples of other factors
-"c423ae21-a0cb-4ec7-aeb1-32971af5b510" = true
+[c423ae21-a0cb-4ec7-aeb1-32971af5b510]
+description = "the factor 0 does not affect the sum of multiples of other factors"
 
-# solutions using include-exclude must extend to cardinality greater than 3
-"17053ba9-112f-4ac0-aadb-0519dd836342" = true
+[17053ba9-112f-4ac0-aadb-0519dd836342]
+description = "solutions using include-exclude must extend to cardinality greater than 3"

--- a/exercises/practice/tournament/.meta/tests.toml
+++ b/exercises/practice/tournament/.meta/tests.toml
@@ -1,34 +1,36 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# just the header if no input
-"67e9fab1-07c1-49cf-9159-bc8671cc7c9c" = true
+[67e9fab1-07c1-49cf-9159-bc8671cc7c9c]
+description = "just the header if no input"
 
-# a win is three points, a loss is zero points
-"1b4a8aef-0734-4007-80a2-0626178c88f4" = true
+[1b4a8aef-0734-4007-80a2-0626178c88f4]
+description = "a win is three points, a loss is zero points"
 
-# a win can also be expressed as a loss
-"5f45ac09-4efe-46e7-8ddb-75ad85f86e05" = true
+[5f45ac09-4efe-46e7-8ddb-75ad85f86e05]
+description = "a win can also be expressed as a loss"
 
-# a different team can win
-"fd297368-efa0-442d-9f37-dd3f9a437239" = true
+[fd297368-efa0-442d-9f37-dd3f9a437239]
+description = "a different team can win"
 
-# a draw is one point each
-"26c016f9-e753-4a93-94e9-842f7b4d70fc" = true
+[26c016f9-e753-4a93-94e9-842f7b4d70fc]
+description = "a draw is one point each"
 
-# There can be more than one match
-"731204f6-4f34-4928-97eb-1c307ba83e62" = true
+[731204f6-4f34-4928-97eb-1c307ba83e62]
+description = "There can be more than one match"
 
-# There can be more than one winner
-"49dc2463-42af-4ea6-95dc-f06cc5776adf" = true
+[49dc2463-42af-4ea6-95dc-f06cc5776adf]
+description = "There can be more than one winner"
 
-# There can be more than two teams
-"6d930f33-435c-4e6f-9e2d-63fa85ce7dc7" = true
+[6d930f33-435c-4e6f-9e2d-63fa85ce7dc7]
+description = "There can be more than two teams"
 
-# typical input
-"97022974-0c8a-4a50-8fe7-e36bdd8a5945" = true
+[97022974-0c8a-4a50-8fe7-e36bdd8a5945]
+description = "typical input"
 
-# incomplete competition (not all pairs have played)
-"fe562f0d-ac0a-4c62-b9c9-44ee3236392b" = true
+[fe562f0d-ac0a-4c62-b9c9-44ee3236392b]
+description = "incomplete competition (not all pairs have played)"
 
-# ties broken alphabetically
-"3aa0386f-150b-4f99-90bb-5195e7b7d3b8" = true
+[3aa0386f-150b-4f99-90bb-5195e7b7d3b8]
+description = "ties broken alphabetically"

--- a/exercises/practice/twelve-days/.meta/tests.toml
+++ b/exercises/practice/twelve-days/.meta/tests.toml
@@ -1,46 +1,48 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# first day a partridge in a pear tree
-"c0b5a5e6-c89d-49b1-a6b2-9f523bff33f7" = true
+[c0b5a5e6-c89d-49b1-a6b2-9f523bff33f7]
+description = "first day a partridge in a pear tree"
 
-# second day two turtle doves
-"1c64508a-df3d-420a-b8e1-fe408847854a" = true
+[1c64508a-df3d-420a-b8e1-fe408847854a]
+description = "second day two turtle doves"
 
-# third day three french hens
-"a919e09c-75b2-4e64-bb23-de4a692060a8" = true
+[a919e09c-75b2-4e64-bb23-de4a692060a8]
+description = "third day three french hens"
 
-# fourth day four calling birds
-"9bed8631-ec60-4894-a3bb-4f0ec9fbe68d" = true
+[9bed8631-ec60-4894-a3bb-4f0ec9fbe68d]
+description = "fourth day four calling birds"
 
-# fifth day five gold rings
-"cf1024f0-73b6-4545-be57-e9cea565289a" = true
+[cf1024f0-73b6-4545-be57-e9cea565289a]
+description = "fifth day five gold rings"
 
-# sixth day six geese-a-laying
-"50bd3393-868a-4f24-a618-68df3d02ff04" = true
+[50bd3393-868a-4f24-a618-68df3d02ff04]
+description = "sixth day six geese-a-laying"
 
-# seventh day seven swans-a-swimming
-"8f29638c-9bf1-4680-94be-e8b84e4ade83" = true
+[8f29638c-9bf1-4680-94be-e8b84e4ade83]
+description = "seventh day seven swans-a-swimming"
 
-# eighth day eight maids-a-milking
-"7038d6e1-e377-47ad-8c37-10670a05bc05" = true
+[7038d6e1-e377-47ad-8c37-10670a05bc05]
+description = "eighth day eight maids-a-milking"
 
-# ninth day nine ladies dancing
-"37a800a6-7a56-4352-8d72-0f51eb37cfe8" = true
+[37a800a6-7a56-4352-8d72-0f51eb37cfe8]
+description = "ninth day nine ladies dancing"
 
-# tenth day ten lords-a-leaping
-"10b158aa-49ff-4b2d-afc3-13af9133510d" = true
+[10b158aa-49ff-4b2d-afc3-13af9133510d]
+description = "tenth day ten lords-a-leaping"
 
-# eleventh day eleven pipers piping
-"08d7d453-f2ba-478d-8df0-d39ea6a4f457" = true
+[08d7d453-f2ba-478d-8df0-d39ea6a4f457]
+description = "eleventh day eleven pipers piping"
 
-# twelfth day twelve drummers drumming
-"0620fea7-1704-4e48-b557-c05bf43967f0" = true
+[0620fea7-1704-4e48-b557-c05bf43967f0]
+description = "twelfth day twelve drummers drumming"
 
-# recites first three verses of the song
-"da8b9013-b1e8-49df-b6ef-ddec0219e398" = true
+[da8b9013-b1e8-49df-b6ef-ddec0219e398]
+description = "recites first three verses of the song"
 
-# recites three verses from the middle of the song
-"c095af0d-3137-4653-ad32-bfb899eda24c" = true
+[c095af0d-3137-4653-ad32-bfb899eda24c]
+description = "recites three verses from the middle of the song"
 
-# recites the whole song
-"20921bc9-cc52-4627-80b3-198cbbfcf9b7" = true
+[20921bc9-cc52-4627-80b3-198cbbfcf9b7]
+description = "recites the whole song"

--- a/exercises/practice/two-fer/.meta/tests.toml
+++ b/exercises/practice/two-fer/.meta/tests.toml
@@ -1,10 +1,12 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# no name given
-"1cf3e15a-a3d7-4a87-aeb3-ba1b43bc8dce" = true
+[1cf3e15a-a3d7-4a87-aeb3-ba1b43bc8dce]
+description = "no name given"
 
-# a name given
-"b4c6dbb8-b4fb-42c2-bafd-10785abe7709" = true
+[b4c6dbb8-b4fb-42c2-bafd-10785abe7709]
+description = "a name given"
 
-# another name given
-"3549048d-1a6e-4653-9a79-b0bda163e8d5" = true
+[3549048d-1a6e-4653-9a79-b0bda163e8d5]
+description = "another name given"

--- a/exercises/practice/word-count/.meta/tests.toml
+++ b/exercises/practice/word-count/.meta/tests.toml
@@ -1,40 +1,42 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# count one word
-"61559d5f-2cad-48fb-af53-d3973a9ee9ef" = true
+[61559d5f-2cad-48fb-af53-d3973a9ee9ef]
+description = "count one word"
 
-# count one of each word
-"5abd53a3-1aed-43a4-a15a-29f88c09cbbd" = true
+[5abd53a3-1aed-43a4-a15a-29f88c09cbbd]
+description = "count one of each word"
 
-# multiple occurrences of a word
-"2a3091e5-952e-4099-9fac-8f85d9655c0e" = true
+[2a3091e5-952e-4099-9fac-8f85d9655c0e]
+description = "multiple occurrences of a word"
 
-# handles cramped lists
-"e81877ae-d4da-4af4-931c-d923cd621ca6" = true
+[e81877ae-d4da-4af4-931c-d923cd621ca6]
+description = "handles cramped lists"
 
-# handles expanded lists
-"7349f682-9707-47c0-a9af-be56e1e7ff30" = true
+[7349f682-9707-47c0-a9af-be56e1e7ff30]
+description = "handles expanded lists"
 
-# ignore punctuation
-"a514a0f2-8589-4279-8892-887f76a14c82" = true
+[a514a0f2-8589-4279-8892-887f76a14c82]
+description = "ignore punctuation"
 
-# include numbers
-"d2e5cee6-d2ec-497b-bdc9-3ebe092ce55e" = true
+[d2e5cee6-d2ec-497b-bdc9-3ebe092ce55e]
+description = "include numbers"
 
-# normalize case
-"dac6bc6a-21ae-4954-945d-d7f716392dbf" = true
+[dac6bc6a-21ae-4954-945d-d7f716392dbf]
+description = "normalize case"
 
-# with apostrophes
-"4185a902-bdb0-4074-864c-f416e42a0f19" = true
+[4185a902-bdb0-4074-864c-f416e42a0f19]
+description = "with apostrophes"
 
-# with quotations
-"be72af2b-8afe-4337-b151-b297202e4a7b" = true
+[be72af2b-8afe-4337-b151-b297202e4a7b]
+description = "with quotations"
 
-# substrings from the beginning
-"8d6815fe-8a51-4a65-96f9-2fb3f6dc6ed6" = true
+[8d6815fe-8a51-4a65-96f9-2fb3f6dc6ed6]
+description = "substrings from the beginning"
 
-# multiple spaces not detected as a word
-"c5f4ef26-f3f7-4725-b314-855c04fb4c13" = true
+[c5f4ef26-f3f7-4725-b314-855c04fb4c13]
+description = "multiple spaces not detected as a word"
 
-# alternating word separators not detected as a word
-"50176e8a-fe8e-4f4c-b6b6-aa9cf8f20360" = true
+[50176e8a-fe8e-4f4c-b6b6-aa9cf8f20360]
+description = "alternating word separators not detected as a word"


### PR DESCRIPTION
Track maintainers found that they wanted to add comments to the tests.toml file to e.g. indicate _why_ a test was not included.
Unfortunately, running configlet sync would re-generate the entire file so any manually added comments were lost.

In this PR we're updating the format of tests.toml files to support adding comments.
We do this by creating a separate table for each test case which has `description` and `include` fields.
Tracks are then free to add additional fields, like a `comment` field, but also any other fields they feel might be useful to them.

configlet has _not_ yet been updated to support this new format, but we hope to do this soon. Sorry for the inconvenience.

For more information, see this discussion: https://github.com/exercism/configlet/issues/186

## Implementation

The PR expects the tests.toml files to be in their original format:

```toml
# <description>
"<uuid>" = <include>
```

This is transformed to:

```toml
[<uuid>]
description = "<description>"
include = <include>
```

## Example

```toml
# one factor has multiples within limit
"361e4e50-c89b-4f60-95ef-5bc5c595490a" = true
```

becomes

```toml
[361e4e50-c89b-4f60-95ef-5bc5c595490a]
description = "one factor has multiples within limit"
include = true
```

## Existing comments

As some tracks have manually added comments to tests, we try to detect them by assuming they are either:

- Added as a line comment _before_ the description (we'll ignore empty lines)
- Added as an inline comment _after_ boolean include value

For any such manually detected comments, we'll add a `comment` field.

## Tracking

https://github.com/exercism/v3-launch/issues/22
