### PR TITLE
Remove outdated configlet usage from CI tasks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,4 +32,3 @@ jobs:
       - run: smalltalkci -s ${{ steps.smalltalkci.outputs.smalltalk-version }}
         shell: bash
         timeout-minutes: 15
-        

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,14 +33,4 @@ jobs:
         shell: bash
         timeout-minutes: 15
         
-  tree:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Fetch configlet
-        uses: exercism/github-actions/configlet-ci@main
-
-      - name: Configlet Tree
-        run: configlet tree --with-difficulty .
+        

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         uses: exercism/github-actions/configlet-ci@main
 
       - name: Configlet Linter
-        run: configlet lint --track-id pharo .
+        run: configlet lint .
     
   test:
     name: Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         uses: exercism/github-actions/configlet-ci@main
 
       - name: Configlet Linter
-        run: configlet lint .
+        run: configlet lint
     
   test:
     name: Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,18 +6,6 @@ on:
   pull_request:
 
 jobs:
-  lint:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Fetch configlet
-        uses: exercism/github-actions/configlet-ci@main
-
-      - name: Configlet Linter
-        run: configlet lint
-    
   test:
     name: Test
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,4 +33,3 @@ jobs:
         shell: bash
         timeout-minutes: 15
         
-        

--- a/config.json
+++ b/config.json
@@ -563,7 +563,7 @@
   "concepts": [],
   "key_features": [],
   "tags": [
-     "paradigm/object_oriented",
+    "paradigm/object_oriented",
     "typing/dynamic",
     "typing/strong",
     "platform/windows",

--- a/config.json
+++ b/config.json
@@ -562,5 +562,13 @@
   },
   "concepts": [],
   "key_features": [],
-  "tags": []
+  "tags": [
+     "paradigm/object_oriented",
+    "typing/dynamic",
+    "typing/strong",
+    "platform/windows",
+    "platform/mac",
+    "platform/linux",
+    "runtime/language_specific"
+  ]
 }


### PR DESCRIPTION
CI failures on #467 raised some possible outdated CI configuration. This is to fix the incorrect configlet usage.