### PR TITLE
🤖 Add authors and contributors to Practice Exercises

### DIFF
--- a/exercises/practice/acronym/.meta/config.json
+++ b/exercises/practice/acronym/.meta/config.json
@@ -1,6 +1,11 @@
 {
   "blurb": "Convert a long phrase to its acronym",
-  "authors": [],
+  "authors": [
+    "macta"
+  ],
+  "contributors": [
+    "bencoman"
+  ],
   "files": {
     "solution": [],
     "test": [],

--- a/exercises/practice/allergies/.meta/config.json
+++ b/exercises/practice/allergies/.meta/config.json
@@ -1,6 +1,11 @@
 {
   "blurb": "Given a person's allergy score, determine whether or not they're allergic to a given item, and their full list of allergies.",
-  "authors": [],
+  "authors": [
+    "macta"
+  ],
+  "contributors": [
+    "bencoman"
+  ],
   "files": {
     "solution": [],
     "test": [],

--- a/exercises/practice/anagram/.meta/config.json
+++ b/exercises/practice/anagram/.meta/config.json
@@ -1,6 +1,11 @@
 {
   "blurb": "Given a word and a list of possible anagrams, select the correct sublist.",
-  "authors": [],
+  "authors": [
+    "macta"
+  ],
+  "contributors": [
+    "bencoman"
+  ],
   "files": {
     "solution": [],
     "test": [],

--- a/exercises/practice/armstrong-numbers/.meta/config.json
+++ b/exercises/practice/armstrong-numbers/.meta/config.json
@@ -1,6 +1,12 @@
 {
   "blurb": "Determine if a number is an Armstrong number",
-  "authors": [],
+  "authors": [
+    "carlotxra"
+  ],
+  "contributors": [
+    "bencoman",
+    "macta"
+  ],
   "files": {
     "solution": [],
     "test": [],

--- a/exercises/practice/atbash-cipher/.meta/config.json
+++ b/exercises/practice/atbash-cipher/.meta/config.json
@@ -1,6 +1,11 @@
 {
   "blurb": "Create an implementation of the atbash cipher, an ancient encryption system created in the Middle East.",
-  "authors": [],
+  "authors": [
+    "macta"
+  ],
+  "contributors": [
+    "bencoman"
+  ],
   "files": {
     "solution": [],
     "test": [],

--- a/exercises/practice/binary/.meta/config.json
+++ b/exercises/practice/binary/.meta/config.json
@@ -1,6 +1,11 @@
 {
   "blurb": "Convert a binary number, represented as a string (e.g. '101010'), to its decimal equivalent using first principles",
-  "authors": [],
+  "authors": [
+    "macta"
+  ],
+  "contributors": [
+    "bencoman"
+  ],
   "files": {
     "solution": [],
     "test": [],

--- a/exercises/practice/bowling/.meta/config.json
+++ b/exercises/practice/bowling/.meta/config.json
@@ -1,6 +1,11 @@
 {
   "blurb": "Score a bowling game",
-  "authors": [],
+  "authors": [
+    "macta"
+  ],
+  "contributors": [
+    "bencoman"
+  ],
   "files": {
     "solution": [],
     "test": [],

--- a/exercises/practice/clock/.meta/config.json
+++ b/exercises/practice/clock/.meta/config.json
@@ -1,6 +1,11 @@
 {
   "blurb": "Implement a clock that handles times without dates.",
-  "authors": [],
+  "authors": [
+    "macta"
+  ],
+  "contributors": [
+    "bencoman"
+  ],
   "files": {
     "solution": [],
     "test": [],

--- a/exercises/practice/collatz-conjecture/.meta/config.json
+++ b/exercises/practice/collatz-conjecture/.meta/config.json
@@ -1,6 +1,11 @@
 {
   "blurb": "Calculate the number of steps to reach 1 using the Collatz conjecture",
-  "authors": [],
+  "authors": [
+    "macta"
+  ],
+  "contributors": [
+    "bencoman"
+  ],
   "files": {
     "solution": [],
     "test": [],

--- a/exercises/practice/darts/.meta/config.json
+++ b/exercises/practice/darts/.meta/config.json
@@ -1,6 +1,11 @@
 {
   "blurb": "Write a function that returns the earned points in a single toss of a Darts game",
-  "authors": [],
+  "authors": [
+    "macta"
+  ],
+  "contributors": [
+    "bencoman"
+  ],
   "files": {
     "solution": [],
     "test": [],

--- a/exercises/practice/diamond/.meta/config.json
+++ b/exercises/practice/diamond/.meta/config.json
@@ -1,6 +1,11 @@
 {
   "blurb": "Given a letter, print a diamond starting with 'A' with the supplied letter at the widest point.",
-  "authors": [],
+  "authors": [
+    "macta"
+  ],
+  "contributors": [
+    "bencoman"
+  ],
   "files": {
     "solution": [],
     "test": [],

--- a/exercises/practice/die/.meta/config.json
+++ b/exercises/practice/die/.meta/config.json
@@ -1,6 +1,12 @@
 {
   "blurb": "A small DSL for dice rolling",
-  "authors": [],
+  "authors": [
+    "macta"
+  ],
+  "contributors": [
+    "bencoman",
+    "samWson"
+  ],
   "files": {
     "solution": [],
     "test": [],

--- a/exercises/practice/etl/.meta/config.json
+++ b/exercises/practice/etl/.meta/config.json
@@ -1,6 +1,11 @@
 {
   "blurb": "We are going to do the `Transform` step of an Extract-Transform-Load.",
-  "authors": [],
+  "authors": [
+    "macta"
+  ],
+  "contributors": [
+    "bencoman"
+  ],
   "files": {
     "solution": [],
     "test": [],

--- a/exercises/practice/flatten-array/.meta/config.json
+++ b/exercises/practice/flatten-array/.meta/config.json
@@ -1,6 +1,8 @@
 {
   "blurb": "Take a nested list and return a single list with all values except nil/null",
-  "authors": [],
+  "authors": [
+    "macta"
+  ],
   "files": {
     "solution": [],
     "test": [],

--- a/exercises/practice/forth/.meta/config.json
+++ b/exercises/practice/forth/.meta/config.json
@@ -1,6 +1,11 @@
 {
   "blurb": "Implement an evaluator for a very simple subset of Forth",
-  "authors": [],
+  "authors": [
+    "macta"
+  ],
+  "contributors": [
+    "bencoman"
+  ],
   "files": {
     "solution": [],
     "test": [],

--- a/exercises/practice/grade-school/.meta/config.json
+++ b/exercises/practice/grade-school/.meta/config.json
@@ -1,6 +1,11 @@
 {
   "blurb": "Given students' names along with the grade that they are in, create a roster for the school",
-  "authors": [],
+  "authors": [
+    "macta"
+  ],
+  "contributors": [
+    "bencoman"
+  ],
   "files": {
     "solution": [],
     "test": [],

--- a/exercises/practice/grains/.meta/config.json
+++ b/exercises/practice/grains/.meta/config.json
@@ -1,6 +1,11 @@
 {
   "blurb": "Calculate the number of grains of wheat on a chessboard given that the number on each square doubles.",
-  "authors": [],
+  "authors": [
+    "macta"
+  ],
+  "contributors": [
+    "bencoman"
+  ],
   "files": {
     "solution": [],
     "test": [],

--- a/exercises/practice/hamming/.meta/config.json
+++ b/exercises/practice/hamming/.meta/config.json
@@ -1,6 +1,11 @@
 {
   "blurb": "Calculate the Hamming difference between two DNA strands.",
-  "authors": [],
+  "authors": [
+    "macta"
+  ],
+  "contributors": [
+    "bencoman"
+  ],
   "files": {
     "solution": [],
     "test": [],

--- a/exercises/practice/hello-world/.meta/config.json
+++ b/exercises/practice/hello-world/.meta/config.json
@@ -1,6 +1,11 @@
 {
   "blurb": "The classical introductory exercise. Just say \"Hello, World!\"",
-  "authors": [],
+  "authors": [
+    "macta"
+  ],
+  "contributors": [
+    "bencoman"
+  ],
   "files": {
     "solution": [],
     "test": [],

--- a/exercises/practice/high-scores/.meta/config.json
+++ b/exercises/practice/high-scores/.meta/config.json
@@ -1,6 +1,11 @@
 {
   "blurb": "Manage a player's High Score list",
-  "authors": [],
+  "authors": [
+    "macta"
+  ],
+  "contributors": [
+    "bencoman"
+  ],
   "files": {
     "solution": [],
     "test": [],

--- a/exercises/practice/isbn-verifier/.meta/config.json
+++ b/exercises/practice/isbn-verifier/.meta/config.json
@@ -1,6 +1,11 @@
 {
   "blurb": "Check if a given string is a valid ISBN-10 number.",
-  "authors": [],
+  "authors": [
+    "macta"
+  ],
+  "contributors": [
+    "bencoman"
+  ],
   "files": {
     "solution": [],
     "test": [],

--- a/exercises/practice/isogram/.meta/config.json
+++ b/exercises/practice/isogram/.meta/config.json
@@ -1,6 +1,11 @@
 {
   "blurb": "Determine if a word or phrase is an isogram.",
-  "authors": [],
+  "authors": [
+    "macta"
+  ],
+  "contributors": [
+    "bencoman"
+  ],
   "files": {
     "solution": [],
     "test": [],

--- a/exercises/practice/leap/.meta/config.json
+++ b/exercises/practice/leap/.meta/config.json
@@ -1,6 +1,11 @@
 {
   "blurb": "Given a year, report if it is a leap year.",
-  "authors": [],
+  "authors": [
+    "macta"
+  ],
+  "contributors": [
+    "bencoman"
+  ],
   "files": {
     "solution": [],
     "test": [],

--- a/exercises/practice/luhn/.meta/config.json
+++ b/exercises/practice/luhn/.meta/config.json
@@ -1,6 +1,12 @@
 {
   "blurb": "Given a number determine whether or not it is valid per the Luhn formula.",
-  "authors": [],
+  "authors": [
+    "raydeejay"
+  ],
+  "contributors": [
+    "bencoman",
+    "macta"
+  ],
   "files": {
     "solution": [],
     "test": [],

--- a/exercises/practice/matching-brackets/.meta/config.json
+++ b/exercises/practice/matching-brackets/.meta/config.json
@@ -1,6 +1,11 @@
 {
   "blurb": "Make sure the brackets and braces all match.",
-  "authors": [],
+  "authors": [
+    "macta"
+  ],
+  "contributors": [
+    "bencoman"
+  ],
   "files": {
     "solution": [],
     "test": [],

--- a/exercises/practice/matrix/.meta/config.json
+++ b/exercises/practice/matrix/.meta/config.json
@@ -1,6 +1,8 @@
 {
   "blurb": "Given a string representing a matrix of numbers, return the rows and columns of that matrix.",
-  "authors": [],
+  "authors": [
+    "macta"
+  ],
   "files": {
     "solution": [],
     "test": [],

--- a/exercises/practice/minesweeper/.meta/config.json
+++ b/exercises/practice/minesweeper/.meta/config.json
@@ -1,6 +1,8 @@
 {
   "blurb": "Add the numbers to a minesweeper board",
-  "authors": [],
+  "authors": [
+    "macta"
+  ],
   "files": {
     "solution": [],
     "test": [],

--- a/exercises/practice/pangram/.meta/config.json
+++ b/exercises/practice/pangram/.meta/config.json
@@ -1,6 +1,11 @@
 {
   "blurb": "Determine if a sentence is a pangram.",
-  "authors": [],
+  "authors": [
+    "macta"
+  ],
+  "contributors": [
+    "bencoman"
+  ],
   "files": {
     "solution": [],
     "test": [],

--- a/exercises/practice/proverb/.meta/config.json
+++ b/exercises/practice/proverb/.meta/config.json
@@ -1,6 +1,11 @@
 {
   "blurb": "For want of a horseshoe nail, a kingdom was lost, or so the saying goes. Output the full text of this proverbial rhyme.",
-  "authors": [],
+  "authors": [
+    "macta"
+  ],
+  "contributors": [
+    "bencoman"
+  ],
   "files": {
     "solution": [],
     "test": [],

--- a/exercises/practice/raindrops/.meta/config.json
+++ b/exercises/practice/raindrops/.meta/config.json
@@ -1,6 +1,11 @@
 {
   "blurb": "Convert a number to a string, the content of which depends on the number's factors.",
-  "authors": [],
+  "authors": [
+    "macta"
+  ],
+  "contributors": [
+    "bencoman"
+  ],
   "files": {
     "solution": [],
     "test": [],

--- a/exercises/practice/resistor-color-duo/.meta/config.json
+++ b/exercises/practice/resistor-color-duo/.meta/config.json
@@ -1,6 +1,11 @@
 {
   "blurb": "Convert color codes, as used on resistors, to a numeric value.",
-  "authors": [],
+  "authors": [
+    "macta"
+  ],
+  "contributors": [
+    "bencoman"
+  ],
   "files": {
     "solution": [],
     "test": [],

--- a/exercises/practice/reverse-string/.meta/config.json
+++ b/exercises/practice/reverse-string/.meta/config.json
@@ -1,6 +1,13 @@
 {
   "blurb": "Reverse a string",
-  "authors": [],
+  "authors": [
+    "macta"
+  ],
+  "contributors": [
+    "bencoman",
+    "chicoary",
+    "samWson"
+  ],
   "files": {
     "solution": [],
     "test": [],

--- a/exercises/practice/robot-simulator/.meta/config.json
+++ b/exercises/practice/robot-simulator/.meta/config.json
@@ -1,6 +1,11 @@
 {
   "blurb": "Write a robot simulator.",
-  "authors": [],
+  "authors": [
+    "macta"
+  ],
+  "contributors": [
+    "bencoman"
+  ],
   "files": {
     "solution": [],
     "test": [],

--- a/exercises/practice/roman-numerals/.meta/config.json
+++ b/exercises/practice/roman-numerals/.meta/config.json
@@ -1,6 +1,11 @@
 {
   "blurb": "Write a function to convert from normal numbers to Roman Numerals.",
-  "authors": [],
+  "authors": [
+    "macta"
+  ],
+  "contributors": [
+    "bencoman"
+  ],
   "files": {
     "solution": [],
     "test": [],

--- a/exercises/practice/secret-handshake/.meta/config.json
+++ b/exercises/practice/secret-handshake/.meta/config.json
@@ -1,6 +1,12 @@
 {
   "blurb": "Given a decimal number, convert it to the appropriate sequence of events for a secret handshake.",
-  "authors": [],
+  "authors": [
+    "carlotxra"
+  ],
+  "contributors": [
+    "bencoman",
+    "macta"
+  ],
   "files": {
     "solution": [],
     "test": [],

--- a/exercises/practice/sieve/.meta/config.json
+++ b/exercises/practice/sieve/.meta/config.json
@@ -1,6 +1,11 @@
 {
   "blurb": "Use the Sieve of Eratosthenes to find all the primes from 2 up to a given number.",
-  "authors": [],
+  "authors": [
+    "macta"
+  ],
+  "contributors": [
+    "bencoman"
+  ],
   "files": {
     "solution": [],
     "test": [],

--- a/exercises/practice/space-age/.meta/config.json
+++ b/exercises/practice/space-age/.meta/config.json
@@ -1,6 +1,11 @@
 {
   "blurb": "Given an age in seconds, calculate how old someone is in terms of a given planet's solar years.",
-  "authors": [],
+  "authors": [
+    "macta"
+  ],
+  "contributors": [
+    "bencoman"
+  ],
   "files": {
     "solution": [],
     "test": [],

--- a/exercises/practice/sum-of-multiples/.meta/config.json
+++ b/exercises/practice/sum-of-multiples/.meta/config.json
@@ -1,6 +1,11 @@
 {
   "blurb": "Given a number, find the sum of all the multiples of particular numbers up to but not including that number.",
-  "authors": [],
+  "authors": [
+    "macta"
+  ],
+  "contributors": [
+    "bencoman"
+  ],
   "files": {
     "solution": [],
     "test": [],

--- a/exercises/practice/tournament/.meta/config.json
+++ b/exercises/practice/tournament/.meta/config.json
@@ -1,6 +1,11 @@
 {
   "blurb": "Tally the results of a small football competition.",
-  "authors": [],
+  "authors": [
+    "macta"
+  ],
+  "contributors": [
+    "bencoman"
+  ],
   "files": {
     "solution": [],
     "test": [],

--- a/exercises/practice/twelve-days/.meta/config.json
+++ b/exercises/practice/twelve-days/.meta/config.json
@@ -1,6 +1,11 @@
 {
   "blurb": "Output the lyrics to 'The Twelve Days of Christmas'",
-  "authors": [],
+  "authors": [
+    "macta"
+  ],
+  "contributors": [
+    "bencoman"
+  ],
   "files": {
     "solution": [],
     "test": [],

--- a/exercises/practice/two-fer/.meta/config.json
+++ b/exercises/practice/two-fer/.meta/config.json
@@ -1,6 +1,11 @@
 {
   "blurb": "Create a sentence of the form \"One for X, one for me.\"",
-  "authors": [],
+  "authors": [
+    "macta"
+  ],
+  "contributors": [
+    "bencoman"
+  ],
   "files": {
     "solution": [],
     "test": [],

--- a/exercises/practice/word-count/.meta/config.json
+++ b/exercises/practice/word-count/.meta/config.json
@@ -1,6 +1,11 @@
 {
   "blurb": "Given a phrase, count the occurrences of each word in that phrase.",
-  "authors": [],
+  "authors": [
+    "macta"
+  ],
+  "contributors": [
+    "bencoman"
+  ],
   "files": {
     "solution": [],
     "test": [],


### PR DESCRIPTION
_If you got tagged in this PR, it is because you are being credited for work you've done in the past on Exercism here, and we want to ensure you don't miss out on the recognition you deserve 🙂_

---

With v3, we've introduced the idea of exercise authors and contributors. This information is stored in the exercises' `.meta/config.json` files (see [the docs](https://github.com/exercism/docs/blob/main/building/tracks/practice-exercises.md#file-metaconfigjson)).

Concept Exercises, which are all new, already contain authors and contributors. Practice Exercises though are missing this information. In this PR, we attempt to populate the authors and contributors of Practice Exercises based on their commit history.

## Maintainer TODO list

These are the things you, the maintainers, should do:

- [ ] Check the authors and contributors, adding/removing users where the data is missing or incorrect
- [ ] Double-check any renamed Practice Exercises
- [ ] Check for Practice Exercises with missing authors, which are most likely due to the author not being on GitHub anymore 
- [ ] Add additional authors if you know that a Practice Exercise has actually been created by more than one author 

**For clarity, authors should be the people who originally created the exercise on this track. Contributors should be people who have substantially contributed to that exercise. PRs for typos or multiple-exercise PRs do not automatically mean someone should be considered a contributor to that exercise. Those non-exercise-specific contributions will get recognition through Exercism's reputation system in v3.**

If you find something needs updating, just push a new commit to this PR.

## Automatic Merging

We will automatically merge this PR before we launch v3, but will give the maximum time we can to maintainers to review it first.

---

_The rest of this issue explains how this PR has been generated. You do not **need** to read it._

## Algorithm

We start out by looking at the current Practice Exercises. For each Practice Exercise, we'll look at the commit history of its files to see which commits touched that Practice Exercise. How renames are handled is discussed in the "Renames" section later in this document. 

Any commit that we can associate with a Practice Exercise is used to determine authorship/contributorship. Here is how we assign authorship/contributorship:

### Authors

1. Find the Git commit author of the oldest commit linked to that Practice Exercise.
2. Find the GitHub username for the Git commit author of that commit
3. Add the GitHub username of the Git commit author to the `authors` key in the `.meta/config.json` file

### Contributors

1. Find the Git commit authors and any co-authors of all but the oldest commit linked to that Practice Exercise. If there is only one commit, there won't be any contributors.
1. Exclude the Git commit author and any co-authors of the oldest commit from the list of Git commit authors (an author is _not_ also a contributor) 
2. Find the GitHub usernames for the Git commit authors and any co-authors of those commits
3. Add the GitHub usernames of the Git commit authors and any co-authors to the `contributor` key in the `.meta/config.json` file

We're using the GitHub GraphQL API to find the username of a commit author and any co-authors. In some cases though, a username cannot be found for a commit (e.g. due to the user account no longer existing), in which case we'll skip the commit. 

## Renames

There are a small number of Practice Exercises that might have been renamed at some point. You can ask Git to "follow" a file over its renames using `git log --follow <file>`, which will also return commits made before renames. Unfortunately, Git does not store renames, it just stores the contents of the renamed files and tries to guess if a file was renamed by looking at its contents. This _can_ (and will) lead to false positives, where Git will think a file has been renamed whereas it hasn't. As we don't want to have incorrect authors/contributors for exercises, we're ignoring renames. The only exception to this are known exercise renames:

- `bracket-push` was renamed to `matching-brackets`
- `retree` was renamed to `satellite`
- `resistor-colors` was renamed to `resistor-color-duo`
- `kindergarden-garden` was renamed to `kindergarten-garden`

If you know of a rename of a Practice Exercise, please check to see if its authors and contributors are correctly set.

## Exclusions

There are some commits that we skip over, which thus don't influence the authors/contributors list:

- Commits authored by `dependabot[bot]`, `dependabot-preview[bot]` or `github-actions[bot]`
- Bulk update PRs made by `ErikSchierboom` or `kytrinx` to update the track

## Tracking

https://github.com/exercism/v3-launch/issues/24

---

cc @bencoman, @carlotxra, @chicoary, @macta, @raydeejay, @samWson as you are referenced in this PR
