### PR TITLE
Update installation scripts to reference `main` branch instead of `ma…

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -130,4 +130,4 @@ ExercismHttpClient
 
 ## How to Upgrade Pharo Exercism
 
-From time to time we may need you to update the libraries in your Pharo Exercism image. Please follow [these instructions](https://github.com/exercism/pharo-smalltalk/blob/master/docs/UPGRADE.md)
+From time to time we may need you to update the libraries in your Pharo Exercism image. Please follow [these instructions](https://github.com/exercism/pharo-smalltalk/blob/main/docs/UPGRADE.md)

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -21,8 +21,8 @@ and launch Pharo with the exercism tools by pasting the following "load script":
 ```smalltalk
 ./pharo-ui Pharo.image eval "
 Iceberg remoteTypeSelector: #httpsUrl.
-Metacello new 
- baseline: 'Exercism'; 
+Metacello new
+ baseline: 'Exercism';
  repository: 'github://exercism/pharo-smalltalk:main/releases/latest';
  load.
 #ExercismManager asClass welcome.
@@ -65,11 +65,10 @@ Finally, copy and paste the following snippet into the playground:
 
 ```smalltalk
 Iceberg remoteTypeSelector: #httpsUrl.
-Metacello new 
- baseline: 'Exercism'; 
+Metacello new
+ baseline: 'Exercism';
  repository: 'github://exercism/pharo-smalltalk:main/releases/latest';
  load.
- 
 #ExercismManager asClass welcome.
 ```
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -21,8 +21,8 @@ and launch Pharo with the exercism tools by pasting the following "load script":
 ```smalltalk
 ./pharo-ui Pharo.image eval "
 Iceberg remoteTypeSelector: #httpsUrl.
-Metacello new
- baseline: 'Exercism';
+Metacello new 
+ baseline: 'Exercism'; 
  repository: 'github://exercism/pharo-smalltalk:main/releases/latest';
  load.
 #ExercismManager asClass welcome.
@@ -65,11 +65,11 @@ Finally, copy and paste the following snippet into the playground:
 
 ```smalltalk
 Iceberg remoteTypeSelector: #httpsUrl.
-Metacello new
- baseline: 'Exercism';
+Metacello new 
+ baseline: 'Exercism'; 
  repository: 'github://exercism/pharo-smalltalk:main/releases/latest';
  load.
-
+ 
 #ExercismManager asClass welcome.
 ```
 


### PR DESCRIPTION
These installation scripts got missed when fixes were made because of the shift from `master` to `main` as the primary development branch.