### PR TITLE
ExercismSubmission will ignore files with no content

### DIFF
--- a/dev/src/ExercismTests/ExercismSubmissionTest.class.st
+++ b/dev/src/ExercismTests/ExercismSubmissionTest.class.st
@@ -89,6 +89,30 @@ ExercismSubmissionTest >> testPopulateFileContentsWith [
 ]
 
 { #category : #tests }
+ExercismSubmissionTest >> testPopulateFileContentsWithSkipsEmptyContent [
+	"Test populating content"
+	| actualNames baseUrl exercismSubmission rootName sourceNames |
+
+	actualNames := #('empty.st' 'readme.md').
+	sourceNames := actualNames first: 2.
+	baseUrl := 'http://data.io/res'.
+
+	exercismSubmission := ExercismSubmission
+		data: (self class	sampleDataFor: 'test-ex' filenames: actualNames baseUrl: baseUrl).
+
+	exercismSubmission
+		populateFileContentsWith: [ :filename | 
+			filename should beginWith: baseUrl.
+			rootName := filename allButFirst: baseUrl exPathString size.
+			sourceNames should include: rootName.
+			rootName , ' contents'.
+			nil].
+		
+	self
+		assert: exercismSubmission contentData size equals: 0.
+]
+
+{ #category : #tests }
 ExercismSubmissionTest >> testSourceFilenames [
 	| exercismSubmission actualNames |
 		
@@ -105,18 +129,13 @@ ExercismSubmissionTest >> testSourceFilenames [
 
 { #category : #tests }
 ExercismSubmissionTest >> testSourceFilenamesWithContentsDo [
-	| exercismSubmission actualNames expectedNames resultingNames |
-		
-	actualNames := #('a.st' 'readme.md' 'b.st').
-	expectedNames := actualNames copyWithout: 'readme.md'.
+	| exercismSubmission resultingNames |
+	
+	exercismSubmission := ExercismSubmission new contentData: ({ 'filename1' -> 'contents' . 'filename2' -> 'contents' } asDictionary).
 	resultingNames := OrderedCollection new.
+	exercismSubmission sourceFilenamesWithContentsDo: [ :name :contents | resultingNames add: name , contents ].
 	
-	exercismSubmission := ExercismSubmission
-		data: (self class sampleDataFor: 'test-ex' filenames: actualNames baseUrl: '/baseUrl').
-	
-	exercismSubmission sourceFilenamesWithContentsDo: [ :name :contents | resultingNames add: name ].
-	
-	self assertCollection: resultingNames asArray equals: expectedNames.
+	self assertCollection: resultingNames asArray equals: #('filename1contents' 'filename2contents').
 	
 	
 		

--- a/dev/src/ExercismTools/ExercismSubmission.class.st
+++ b/dev/src/ExercismTools/ExercismSubmission.class.st
@@ -115,13 +115,14 @@ ExercismSubmission >> isValid [
 ]
 
 { #category : #retrieving }
-ExercismSubmission >> populateFileContentsWith: aBlockClosure [ 
-	
-	| baseUrl |
-	baseUrl := self baseUrl.
-	
-	self sourceFilenames do: [ :filename |
-		self contentData at: filename put: (aBlockClosure value: baseUrl, filename) ]
+ExercismSubmission >> populateFileContentsWith: aBlockClosure [
+	self sourceFilenames
+		do: [ :filename | 
+			| fileContent |
+			fileContent := aBlockClosure value:
+				self baseUrl , filename.
+			fileContent
+				ifNotNil: [ self contentData at: filename put: fileContent ] ]
 ]
 
 { #category : #accessing }
@@ -137,11 +138,9 @@ ExercismSubmission >> sourceFilenames [
 
 { #category : #retrieving }
 ExercismSubmission >> sourceFilenamesWithContentsDo: aBlockClosure [
-	self sourceFilenames
-		do: [ :filename | 
-			| source |
-			source := self contentData at: filename ifAbsent: [''].
-			aBlockClosure value: filename value: source ]
+	self contentData
+		keysAndValuesDo:
+			[ :filename :contents | aBlockClosure value: filename value: contents ]
 ]
 
 { #category : #storing }


### PR DESCRIPTION
Fixes #500 and #499 

- necessitated a decoupling of the files from the valid files; the iterator now only uses the content dict for both filenames and contents