### PR TITLE
Upon submission, the TestResults will be the last file

### DIFF
--- a/dev/src/ExercismTests/ExercismExerciseTest.class.st
+++ b/dev/src/ExercismTests/ExercismExerciseTest.class.st
@@ -159,13 +159,13 @@ ExercismExerciseTest >> testSolutionSources [
 	sources := TestmanyTest exercise solutionSources.
 	
 	classes := {Testmany. TestOtherClass. TestOtherClassTest }.
-	classNames := (classes collect: [ :c | ClassDescription exTonelClassFilenameFor: c name ]) copyWithFirst: 'TestResults.txt'.
+	classNames := (classes collect: [ :c | ClassDescription exTonelClassFilenameFor: c name ]) copyWith: 'TestResults.txt'.
 	
 	self assertCollection: sources keys asSet equals: classNames asSet.
 	
-	(sources at: classNames first) should includeSubstring: 'Tested on:'.
-	(sources at: classNames second) should includeSubstring: '#name : #', classes first name.
-	(sources at: classNames last) should includeSubstring: '#name : #', classes last name.
+	(sources at: classNames last) should includeSubstring: 'Tested on:'.
+	(sources at: classNames first) should includeSubstring: '#name : #', classes first name.
+	(sources at: classNames allButLast last) should includeSubstring: '#name : #', classes last name.
 ]
 
 { #category : #tests }
@@ -174,9 +174,10 @@ ExercismExerciseTest >> testSolutionSourcesWithExtension [
 	
 	sources := TestExExtensionTest exercise solutionSources.
 	
-	classNames := {'TestResults.txt'. 
-	ClassDescription exTonelClassFilenameFor: #TestExtension. 
-	ClassDescription exTonelExtensionFilenameFor: #String  }. 
+	classNames := {
+        ClassDescription exTonelClassFilenameFor: #TestExtension. 
+        ClassDescription exTonelExtensionFilenameFor: #String.
+        'TestResults.txt' }. 
 	
 	self assertCollection: sources keys asSet equals: classNames asSet.
 ]

--- a/dev/src/ExercismTools/ExercismExercise.class.st
+++ b/dev/src/ExercismTools/ExercismExercise.class.st
@@ -346,9 +346,9 @@ ExercismExercise >> solutionSources [
 	
 	"Build result in the order we want files displayed by Exercism web interface"
 	resultDictionary := OrderedDictionary new.
-	resultDictionary at: 'TestResults.txt' put: testResult exercismSummary.
 	solutionFileNames do: [ :filename | 
 		resultDictionary at: filename put: ( packageFileMap at: filename) contents ].
+	resultDictionary at: 'TestResults.txt' put: testResult exercismSummary.
 	^ resultDictionary
 
 ]


### PR DESCRIPTION
This makes mentoring easier, particularly when there are multiple iterations in the student's exercise solution.

Currently: 
![image](https://user-images.githubusercontent.com/122470/159747956-932980e6-f11a-4b9c-bf35-c6dfbd0d7091.png)

With this change: 
![image](https://user-images.githubusercontent.com/122470/159748064-3a185a61-6db5-409a-b2ab-02aeca441780.png)
