### PR TITLE
409-Resolves problem with loading dependent classes within package(exercise)

### DIFF
--- a/dev/src/ExercismDev/ExercismReviewCommand.class.st
+++ b/dev/src/ExercismDev/ExercismReviewCommand.class.st
@@ -41,9 +41,8 @@ ExercismReviewCommand >> execute [
 	^self executeCheckingToken: [ | submission snapshot |
 
 		submission := self fetchLatestSubmission.
-
-		self fetchExerciseFilesFor: submission.
-		snapshot := self createSnapshotFor: submission.
+		submission fetchExerciseFilesUsing: self httpClient.
+		snapshot := submission createSnapshotFromDefinitions.
 	
 		ExercismReview for: submission with: snapshot.
 	]

--- a/dev/src/ExercismDev/ExercismReviewCommand.class.st
+++ b/dev/src/ExercismDev/ExercismReviewCommand.class.st
@@ -41,7 +41,7 @@ ExercismReviewCommand >> execute [
 	^self executeCheckingToken: [ | submission snapshot |
 
 		submission := self fetchLatestSubmission.
-		submission fetchExerciseFilesUsing: self httpClient.
+		self fetchExerciseFilesFor: submission.
 		snapshot := submission createSnapshotFromDefinitions.
 	
 		ExercismReview for: submission with: snapshot.

--- a/dev/src/ExercismTests/ExercismDownloadCommandTest.class.st
+++ b/dev/src/ExercismTests/ExercismDownloadCommandTest.class.st
@@ -5,31 +5,6 @@ Class {
 }
 
 { #category : #tests }
-ExercismDownloadCommandTest >> prepareMockPackageWithDependentClasses [
-
-|aClass bClass cClass|
-
-aClass := Object subclass: #AMock
-	instanceVariableNames: ''
-	classVariableNames: ''
-	package: 'Exercise@DependencyMock'.
-
-bClass := Object subclass: #BMock
-	instanceVariableNames: ''
-	classVariableNames: ''
-	package: 'Exercise@DependencyMock'.
-
-cClass := Object subclass: #CMock
-	instanceVariableNames: ''
-	classVariableNames: ''
-	package: 'Exercise@DependencyMock'.	
-
-aClass compile: 'mockMethod ^ BMock mockMethod'.
-bClass compile: 'mockMethod ^ CMock mockMethod'.
-cClass compile: 'mockMethod ^ ''Call from class: '', self class name'
-]
-
-{ #category : #tests }
 ExercismDownloadCommandTest >> testExecuteDownloading [
 
 	| cmd exercise solutionData mockHttpClient mockParser mockClass baseUrl sourceCode |

--- a/dev/src/ExercismTests/ExercismDownloadCommandTest.class.st
+++ b/dev/src/ExercismTests/ExercismDownloadCommandTest.class.st
@@ -5,6 +5,31 @@ Class {
 }
 
 { #category : #tests }
+ExercismDownloadCommandTest >> prepareMockPackageWithDependentClasses [
+
+|aClass bClass cClass|
+
+aClass := Object subclass: #AMock
+	instanceVariableNames: ''
+	classVariableNames: ''
+	package: 'Exercise@DependencyMock'.
+
+bClass := Object subclass: #BMock
+	instanceVariableNames: ''
+	classVariableNames: ''
+	package: 'Exercise@DependencyMock'.
+
+cClass := Object subclass: #CMock
+	instanceVariableNames: ''
+	classVariableNames: ''
+	package: 'Exercise@DependencyMock'.	
+
+aClass compile: 'mockMethod ^ BMock mockMethod'.
+bClass compile: 'mockMethod ^ CMock mockMethod'.
+cClass compile: 'mockMethod ^ ''Call from class: '', self class name'
+]
+
+{ #category : #tests }
 ExercismDownloadCommandTest >> testExecuteDownloading [
 
 	| cmd exercise solutionData mockHttpClient mockParser mockClass baseUrl sourceCode |

--- a/dev/src/ExercismTests/ExercismDownloadCommandTest.class.st
+++ b/dev/src/ExercismTests/ExercismDownloadCommandTest.class.st
@@ -18,7 +18,6 @@ ExercismDownloadCommandTest >> testExecuteDownloading [
 	[  
 	cmd := (ExercismDownloadCommand
 				from: mockHttpClient track: 'pharo' exercise: 'test-exercise')
-					parser: mockParser;
 					yourself.
 	
 	exercise := cmd execute.
@@ -43,7 +42,7 @@ ExercismDownloadCommandTest >> testExecuteDownloading [
 	(mockHttpClient expect getResource: Any)  
 		specifying: [ :resName :count | 
 			resName should equal: (baseUrl,'/test{1}.st' format: count asString).
-			'Some source', count printString ].
+			''].
 		
 	mockClass := Class asMock.
 	

--- a/dev/src/ExercismTests/ExercismReviewCommandTest.class.st
+++ b/dev/src/ExercismTests/ExercismReviewCommandTest.class.st
@@ -1,11 +1,11 @@
 Class {
-	#name : #ExercismDownloadCommandTest,
+	#name : #ExercismReviewCommandTest,
 	#superclass : #TestCase,
 	#category : #'ExercismTests-UnitTests'
 }
 
 { #category : #running }
-ExercismDownloadCommandTest >> tearDown [
+ExercismReviewCommandTest >> tearDown [
 	"all known mock mutations should be recovered"
 	ExercismExercise recoverFromGHMutation.
 	TonelReader recoverFromGHMutation.
@@ -13,22 +13,24 @@ ExercismDownloadCommandTest >> tearDown [
 ]
 
 { #category : #tests }
-ExercismDownloadCommandTest >> testExecuteDownloading [
+ExercismReviewCommandTest >> testExecuteReview [
 
-	| cmd exercise solutionData mockHttpClient mockReader baseUrl sourceCode |
+	| cmd aReview solutionData mockHttpClient mockReader baseUrl |
 	Any strictMocks: false.
 
 	[ 
-		cmd := (ExercismDownloadCommand
+		cmd := ExercismReviewCommand
 		        from: mockHttpClient
-		        track: 'pharo'
-		        exercise: 'test-exercise') yourself.
+		        reviewId: '12345'.
 
-		exercise := cmd execute.
+		aReview := cmd execute.
 
-		self assert: exercise notNil description: 'Get a result'.
-		self assert: (exercise contentsFor: 'test1.st' ifAbsent: '') equals: 'Some source1'.
-		self assert: (exercise contentsFor: 'test2.st' ifAbsent: '') equals: 'Some source2'.
+		self assert: aReview notNil description: 'Get a result'.
+
+		self assert: (aReview submission contentsFor: 'test1.st' ifAbsent: '') equals: 'Some source1'.
+		self assert: (aReview submission contentsFor: 'test2.st' ifAbsent: '') equals: 'Some source2'.
+		
+		self assert: aReview codeSnapshot definitions isEmpty description: 'Review should contain empty code snapshot'.
 	] 
 	runWithMockSetup: [ 
 		mockHttpClient := ExercismHttpClient asMock.
@@ -42,8 +44,8 @@ ExercismDownloadCommandTest >> testExecuteDownloading [
 
 		mockHttpClient expect verifyToken atLeastOnce.
 		(mockHttpClient expect
-			 getLatestExercise: 'test-exercise'
-			 for: 'pharo') willReturn: solutionData asJSON.
+			 getSpecifiedExercise: '12345'
+		) willReturn: solutionData asJSON.
 
 		(mockHttpClient expect getResource: Any) specifying: [ :resName :count | 
 			resName should equal:

--- a/dev/src/ExercismTests/ExercismSubmissionTest.class.st
+++ b/dev/src/ExercismTests/ExercismSubmissionTest.class.st
@@ -232,7 +232,7 @@ ExercismSubmissionTest >> testLoadingDependentClasses [
 	exercismSubmission contentData: self prepareMockContentData.
 
 	"this will effectively load dependent classes"
-	exercismSubmission loadDefinitionsFromDirectory.
+	exercismSubmission installDefinitionsFromSnapshot.
 	loadedPackage := RPackageOrganizer default packageNamed: #'Exercise@DependencyMock' ifAbsent: [nil].
 	self deny: loadedPackage isNil.
 	self assert: (loadedPackage includesClassNamed: #AMock).

--- a/dev/src/ExercismTests/ExercismSubmissionTest.class.st
+++ b/dev/src/ExercismTests/ExercismSubmissionTest.class.st
@@ -7,6 +7,106 @@ Class {
 	#category : #'ExercismTests-UnitTests'
 }
 
+{ #category : #private }
+ExercismSubmissionTest class >> mockSnapshotSTON [
+^	'MCSnapshot {
+	#definitions : OrderedCollection [
+		MCOrganizationDefinition {
+			#categories : [
+				#''Exercise@DependencyMock''
+			]
+		},
+		MCMethodDefinition {
+			#classIsMeta : false,
+			#source : ''mockMethod ^ BMock mockMethod'',
+			#category : #''as yet unclassified'',
+			#selector : #mockMethod,
+			#className : #AMock
+		},
+		MCMethodDefinition {
+			#classIsMeta : false,
+			#source : ''mockMethod ^ CMock mockMethod'',
+			#category : #''as yet unclassified'',
+			#selector : #mockMethod,
+			#className : #BMock
+		},
+		MCMethodDefinition {
+			#classIsMeta : false,
+			#source : ''mockMethod ^ \''Call from class: \'', self class name'',
+			#category : #''as yet unclassified'',
+			#selector : #mockMethod,
+			#className : #CMock
+		},
+		MCClassDefinition {
+			#name : #AMock,
+			#superclassName : #BMock,
+			#variables : OrderedCollection [ ],
+			#category : #''Exercise@DependencyMock'',
+			#type : #normal,
+			#comment : '''',
+			#commentStamp : '''',
+			#traitComposition : ''{}'',
+			#classTraitComposition : ''{}''
+		},
+		MCClassDefinition {
+			#name : #CMock,
+			#superclassName : #Object,
+			#variables : OrderedCollection [ ],
+			#category : #''Exercise@DependencyMock'',
+			#type : #normal,
+			#comment : '''',
+			#commentStamp : '''',
+			#traitComposition : ''{}'',
+			#classTraitComposition : ''{}''
+		},
+		MCClassDefinition {
+			#name : #BMock,
+			#superclassName : #CMock,
+			#variables : OrderedCollection [ ],
+			#category : #''Exercise@DependencyMock'',
+			#type : #normal,
+			#comment : '''',
+			#commentStamp : '''',
+			#traitComposition : ''{}'',
+			#classTraitComposition : ''{}''
+		}
+	],
+	#classDefinitionCache : {
+		#AMock : @8,
+		#CMock : @10,
+		#BMock : @12
+	}
+}'
+]
+
+{ #category : #tests }
+ExercismSubmissionTest class >> prepareMockPackageWithDependentClasses [
+" this is used for generating STON representation of MCSnapshot (see class side method), we don't need to create classes during test"
+|aClass bClass cClass aPackage|
+
+	cClass := Object subclass: #CMock
+		instanceVariableNames: ''
+		classVariableNames: ''
+		package: 'Exercise@DependencyMock'.
+		
+	bClass := (self class environment at: #CMock) subclass: #BMock
+		instanceVariableNames: ''
+		classVariableNames: ''
+		package: 'Exercise@DependencyMock'.
+
+	aClass := (self class environment at: #BMock) subclass: #AMock
+		instanceVariableNames: ''
+		classVariableNames: ''
+		package: 'Exercise@DependencyMock'.
+
+	aClass compile: 'mockMethod ^ BMock mockMethod'.
+	bClass compile: 'mockMethod ^ CMock mockMethod'.
+	cClass compile: 'mockMethod ^ ''Call from class: '', self class name'.
+
+	aPackage := RPackageOrganizer default packageNamed: 'Exercise@DependencyMock'.
+	^ TonelWriter new toSTON: aPackage snapshot.
+]
+
 { #category : #'test-data' }
 ExercismSubmissionTest class >> sampleDataFor: testName [
 	^self sampleDataFor: testName filenames: {'test1.st'. 'test.md'. 'test2.st'} baseUrl: '/files'
@@ -25,7 +125,38 @@ ExercismSubmissionTest class >> sampleDataFor: testName filenames: filenameList 
 			
 ]
 
-{ #category : #test }
+{ #category : #tests }
+ExercismSubmissionTest >> mockClassesSnapshot [
+
+	^ STON fromString: self class mockSnapshotSTON
+]
+
+{ #category : #tests }
+ExercismSubmissionTest >> prepareMockContentData [
+	"prepareContentData in expected dictionary format"
+
+	|memoryFileRef contentData|
+	memoryFileRef := FileSystem memory root.
+	(TonelWriter on: memoryFileRef) writeSnapshot: self mockClassesSnapshot.
+	
+	"Remove the package file as its not needed for Exercism"
+	(memoryFileRef / 'Exercise@DependencyMock' / 'package.st') delete.
+	contentData := memoryFileRef allFiles collect: [:sourceFile |
+		sourceFile basename -> sourceFile contents
+	 ].
+
+	^ contentData asDictionary
+]
+
+{ #category : #running }
+ExercismSubmissionTest >> tearDown [ 
+	|aPackage|
+	aPackage := RPackageOrganizer default packageNamed: 'Exercise@DependencyMock' ifAbsent: [nil].
+	aPackage ifNotNil: [ aPackage removeFromSystem].
+	super tearDown
+]
+
+{ #category : #tests }
 ExercismSubmissionTest >> testErrorMessage [
 
 	| exercismSubmission |
@@ -36,7 +167,7 @@ ExercismSubmissionTest >> testErrorMessage [
 	
 ]
 
-{ #category : #test }
+{ #category : #tests }
 ExercismSubmissionTest >> testExerciseClassName [
 
 	| exercismSubmission |
@@ -44,6 +175,16 @@ ExercismSubmissionTest >> testExerciseClassName [
 		data: (self class sampleDataFor: 'test-exercise').
 		
 	self assert: exercismSubmission exerciseClassName equals: 'TestExercise'.
+]
+
+{ #category : #tests }
+ExercismSubmissionTest >> testExercisePackageName [
+
+	| exercismSubmission |
+	exercismSubmission := ExercismSubmission
+		data: (self class sampleDataFor: 'hello-world').
+		
+	self assert: exercismSubmission exercisePackageName equals: 'Exercise@HelloWorld'.
 ]
 
 { #category : #tests }
@@ -59,6 +200,48 @@ ExercismSubmissionTest >> testFilenames [
 	
 	
 		
+]
+
+{ #category : #tests }
+ExercismSubmissionTest >> testLatestExercisePackageSourceDir [
+	
+	| exercismSubmission fileRef firstFile sndFile|
+	exercismSubmission := ExercismSubmission
+		data: (self class sampleDataFor: 'exercism-mock').
+	exercismSubmission contentData: ({ 'filename1' -> 'contents' . 'filename2' -> 'contents2' } asDictionary).
+	fileRef := exercismSubmission latestExercisePackageSourceDir.
+	
+	"test if Memory file reference is created with hiearchy: Package dir -> sourceFiles"
+	self assert: fileRef isDirectory.
+	self deny: (fileRef directoriesMatching: exercismSubmission exercisePackageName) isEmpty.
+	firstFile := fileRef allFiles first.
+	self assert: firstFile basename equals: 'filename1'.
+	self assert: firstFile contents equals: 'contents'.
+	sndFile := fileRef allFiles second.
+	self assert: sndFile basename equals: 'filename2'.
+	self assert: sndFile contents equals: 'contents2'.
+]
+
+{ #category : #tests }
+ExercismSubmissionTest >> testLoadingDependentClasses [
+	| exercismSubmission loadedPackage|
+	exercismSubmission := ExercismSubmission
+		data: (self class sampleDataFor: 'dependency-mock').
+		
+	"prepare dependent classes from mock snapshot"
+	exercismSubmission contentData: self prepareMockContentData.
+
+	"this will effectively load dependent classes"
+	exercismSubmission loadDefinitionsFromDirectory.
+	loadedPackage := RPackageOrganizer default packageNamed: #'Exercise@DependencyMock' ifAbsent: [nil].
+	self deny: loadedPackage isNil.
+	self assert: (loadedPackage includesClassNamed: #AMock).
+	self assert: (loadedPackage includesClassNamed: #BMock).
+	self assert: (loadedPackage includesClassNamed: #CMock).
+	
+	"test hiearchy dependencies"
+	self assert:	((self class environment at: #BMock) inheritsFrom: (self class environment at: #CMock)).
+		self assert:	((self class environment at: #AMock) inheritsFrom: (self class environment at: #BMock)).
 ]
 
 { #category : #tests }

--- a/dev/src/ExercismTools/ExercismDownloadCommand.class.st
+++ b/dev/src/ExercismTools/ExercismDownloadCommand.class.st
@@ -39,11 +39,10 @@ ExercismDownloadCommand >> execute [
 
 { #category : #internal }
 ExercismDownloadCommand >> installExerciseFor: submission [
+	
+	"submission will put sources to memory directory and load definitions using Tonel reader"
+	submission loadDefinitionsFromDirectory.
 
-	submission
-		sourceFilenamesWithContentsDo:
-			[ :filename :contents | (self parser documentFrom: contents) do: [ :def | def load ] ].
-		
 	SystemAnnouncer uniqueInstance
 		announce: (RPackageRegistered to: submission exercise exercisePackage).
 	

--- a/dev/src/ExercismTools/ExercismDownloadCommand.class.st
+++ b/dev/src/ExercismTools/ExercismDownloadCommand.class.st
@@ -30,7 +30,7 @@ ExercismDownloadCommand >> execute [
 
 			submission := self fetchLatestSubmission.
 
-			self fetchExerciseFilesFor: submission.
+			submission fetchExerciseFilesUsing: self httpClient.
 			self installExerciseFor: submission.
 			submission storeSolutionId.
 
@@ -40,8 +40,8 @@ ExercismDownloadCommand >> execute [
 { #category : #internal }
 ExercismDownloadCommand >> installExerciseFor: submission [
 	
-	"submission will put sources to memory directory and load definitions using Tonel reader"
-	submission loadDefinitionsFromDirectory.
+	"submission will put sources to memory directory and load definitions from snapshot"
+	submission installDefinitionsFromSnapshot.
 
 	SystemAnnouncer uniqueInstance
 		announce: (RPackageRegistered to: submission exercise exercisePackage).

--- a/dev/src/ExercismTools/ExercismDownloadCommand.class.st
+++ b/dev/src/ExercismTools/ExercismDownloadCommand.class.st
@@ -27,10 +27,9 @@ ExercismDownloadCommand class >> track: trackId exercise: exerciseId [
 ExercismDownloadCommand >> execute [
 	^ self
 		executeCheckingToken: [ | submission |
-
+			
 			submission := self fetchLatestSubmission.
-
-			submission fetchExerciseFilesUsing: self httpClient.
+			self fetchExerciseFilesFor: submission. 
 			self installExerciseFor: submission.
 			submission storeSolutionId.
 

--- a/dev/src/ExercismTools/ExercismFetchCommand.class.st
+++ b/dev/src/ExercismTools/ExercismFetchCommand.class.st
@@ -27,22 +27,6 @@ ExercismFetchCommand >> fetchLatestSubmission [
 	^ExercismSubmission data: response
 ]
 
-{ #category : #accessing }
-ExercismFetchCommand >> initialize [
-	super initialize.
-	self parser: TonelParser new.
-]
-
-{ #category : #accessing }
-ExercismFetchCommand >> parser [
-	^ parser
-]
-
-{ #category : #accessing }
-ExercismFetchCommand >> parser: aTonelParser [
-	parser := aTonelParser
-]
-
 { #category : #internal }
 ExercismFetchCommand >> retrieveLatestData [
 	^self subclassResponsibility 

--- a/dev/src/ExercismTools/ExercismSubmission.class.st
+++ b/dev/src/ExercismTools/ExercismSubmission.class.st
@@ -6,8 +6,7 @@ Class {
 	#superclass : #Object,
 	#instVars : [
 		'exercismData',
-		'contentData',
-		'tonelReader'
+		'contentData'
 	],
 	#category : #'ExercismTools-Core'
 }
@@ -67,9 +66,10 @@ ExercismSubmission >> createSnapshotFromDefinitions [
 ExercismSubmission >> definitionsToLoadFromDirectory [
 	
 	"reader will return definitions to be loaded from directory containing package directory and .st files with classes"
-	self tonelReader packageDirectory: self exercisePackageName.
-	self tonelReader loadDefinitions.
-	^ self tonelReader definitions.
+	| tonelReader | 
+	tonelReader := TonelReader on: self latestExercisePackageSourceDir fileName: self exercisePackageName.
+	tonelReader loadDefinitions.
+	^ tonelReader definitions.
 
 ]
 
@@ -118,13 +118,6 @@ ExercismSubmission >> exercismData [
 { #category : #accessing }
 ExercismSubmission >> exercismData: anObject [
 	exercismData := anObject
-]
-
-{ #category : #internal }
-ExercismSubmission >> fetchExerciseFilesUsing: aHttpClient [
-
-	"Default http client can be bypassed by parameter"
-	self populateFileContentsWith: [ :filename | aHttpClient getResource: filename ]
 ]
 
 { #category : #accessing }
@@ -181,13 +174,6 @@ ExercismSubmission >> populateFileContentsWith: aBlockClosure [
 				ifNotNil: [ self contentData at: filename put: fileContent ] ]
 ]
 
-{ #category : #internal }
-ExercismSubmission >> setTonelReader [ 
-	
-	tonelReader := TonelReader on: self latestExercisePackageSourceDir fileName: self exercisePackageName.
-	^ tonelReader 
-]
-
 { #category : #accessing }
 ExercismSubmission >> solutionId [
 	^self exercismData at: 'id'
@@ -209,18 +195,6 @@ ExercismSubmission >> sourceFilenamesWithContentsDo: aBlockClosure [
 { #category : #storing }
 ExercismSubmission >> storeSolutionId [
 	self exercise ifNotNil: [:exercise | exercise storeSolutionId: self solutionId]
-]
-
-{ #category : #accessing }
-ExercismSubmission >> tonelReader [ 
-	
-	^ tonelReader ifNil: [self setTonelReader]
-]
-
-{ #category : #accessing }
-ExercismSubmission >> tonelReader: aReader [
-	
-	tonelReader := aReader
 ]
 
 { #category : #accessing }

--- a/dev/src/ExercismTools/ExercismSubmission.class.st
+++ b/dev/src/ExercismTools/ExercismSubmission.class.st
@@ -6,7 +6,8 @@ Class {
 	#superclass : #Object,
 	#instVars : [
 		'exercismData',
-		'contentData'
+		'contentData',
+		'tonelReader'
 	],
 	#category : #'ExercismTools-Core'
 }
@@ -52,6 +53,24 @@ ExercismSubmission >> contentData: anObject [
 { #category : #accessing }
 ExercismSubmission >> contentsFor: aString ifAbsent: anObject [ 
 	^self contentData at: aString
+]
+
+{ #category : #internal }
+ExercismSubmission >> createSnapshotFromDefinitions [
+
+	"return MC snapshot from definitions that can be loaded or submitted"
+	^ MCSnapshot fromDefinitions: self definitionsToLoadFromDirectory
+
+]
+
+{ #category : #internal }
+ExercismSubmission >> definitionsToLoadFromDirectory [
+	
+	"reader will return definitions to be loaded from directory containing package directory and .st files with classes"
+	self tonelReader packageDirectory: self exercisePackageName.
+	self tonelReader loadDefinitions.
+	^ self tonelReader definitions.
+
 ]
 
 { #category : #accessing }
@@ -101,6 +120,13 @@ ExercismSubmission >> exercismData: anObject [
 	exercismData := anObject
 ]
 
+{ #category : #internal }
+ExercismSubmission >> fetchExerciseFilesUsing: aHttpClient [
+
+	"Default http client can be bypassed by parameter"
+	self populateFileContentsWith: [ :filename | aHttpClient getResource: filename ]
+]
+
 { #category : #accessing }
 ExercismSubmission >> filenames [
 	^self exercismData at: 'files'
@@ -111,6 +137,14 @@ ExercismSubmission >> initialize [
 
 	super initialize.
 	self contentData: Dictionary new.
+]
+
+{ #category : #internal }
+ExercismSubmission >> installDefinitionsFromSnapshot [
+
+	"tonel reader will load definitions from directory containing package directory and .st files with classes, creates MC snapshot and install package with exercise to default package organizer"
+	
+	self createSnapshotFromDefinitions install
 ]
 
 { #category : #storing }
@@ -136,20 +170,6 @@ ExercismSubmission >> latestExercisePackageSourceDir [
 	^ memFileRef 
 ]
 
-{ #category : #internal }
-ExercismSubmission >> loadDefinitionsFromDirectory [
-
-	| reader aSnapshot|
-	
-	"reader will load definitions from directory containing package directory and .st files with classes"
-	reader := TonelReader on: self latestExercisePackageSourceDir fileName: self exercisePackageName.
-	reader loadDefinitions.
-	
-	"installing snapshot will resolve dependencies between classes in same package"
-	aSnapshot := MCSnapshot fromDefinitions: reader definitions.
-	aSnapshot install
-]
-
 { #category : #retrieving }
 ExercismSubmission >> populateFileContentsWith: aBlockClosure [
 	self sourceFilenames
@@ -159,6 +179,13 @@ ExercismSubmission >> populateFileContentsWith: aBlockClosure [
 				self baseUrl , filename.
 			fileContent
 				ifNotNil: [ self contentData at: filename put: fileContent ] ]
+]
+
+{ #category : #internal }
+ExercismSubmission >> setTonelReader [ 
+	
+	tonelReader := TonelReader on: self latestExercisePackageSourceDir fileName: self exercisePackageName.
+	^ tonelReader 
 ]
 
 { #category : #accessing }
@@ -182,6 +209,18 @@ ExercismSubmission >> sourceFilenamesWithContentsDo: aBlockClosure [
 { #category : #storing }
 ExercismSubmission >> storeSolutionId [
 	self exercise ifNotNil: [:exercise | exercise storeSolutionId: self solutionId]
+]
+
+{ #category : #accessing }
+ExercismSubmission >> tonelReader [ 
+	
+	^ tonelReader ifNil: [self setTonelReader]
+]
+
+{ #category : #accessing }
+ExercismSubmission >> tonelReader: aReader [
+	
+	tonelReader := aReader
 ]
 
 { #category : #accessing }

--- a/dev/src/ExercismTools/ExercismSubmission.class.st
+++ b/dev/src/ExercismTools/ExercismSubmission.class.st
@@ -85,6 +85,12 @@ ExercismSubmission >> exerciseId [
 	^(self exercismData at: 'exercise') at: 'id'
 ]
 
+{ #category : #internal }
+ExercismSubmission >> exercisePackageName [
+
+	^ ExercismManager exercisePrefix, '@', self exerciseClassName 
+]
+
 { #category : #accessing }
 ExercismSubmission >> exercismData [
 	^ exercismData
@@ -112,6 +118,36 @@ ExercismSubmission >> isValid [
 	"Answer true if the submission resulted in a valid exercise"
 	
 	^(self exercismData includesKey: 'error') not and: [ self exercise notNil ]
+]
+
+{ #category : #internal }
+ExercismSubmission >> latestExercisePackageSourceDir [
+
+	"return memory file reference with retreived latest exercise souuces - needed for tonel reader"
+	|memFileRef packageDir|
+	memFileRef := FileSystem memory root.
+	packageDir := (memFileRef / self exercisePackageName) ensureCreateDirectory.
+	self sourceFilenamesWithContentsDo: [:fileName :sourceString |
+		"do write files here"
+		|sourceFile|
+		sourceFile := packageDir / fileName.
+		sourceFile writeStreamDo: [:aStream | aStream nextPutAll: sourceString ]
+	].
+	^ memFileRef 
+]
+
+{ #category : #internal }
+ExercismSubmission >> loadDefinitionsFromDirectory [
+
+	| reader aSnapshot|
+	
+	"reader will load definitions from directory containing package directory and .st files with classes"
+	reader := TonelReader on: self latestExercisePackageSourceDir fileName: self exercisePackageName.
+	reader loadDefinitions.
+	
+	"installing snapshot will resolve dependencies between classes in same package"
+	aSnapshot := MCSnapshot fromDefinitions: reader definitions.
+	aSnapshot install
 ]
 
 { #category : #retrieving }


### PR DESCRIPTION
- fixes #409 
- this will effectively resolve loading exercise, where source files contain dependent classes (one class is subclass of another)
- Tonel format used in Pharo uses one file per class for serialization from/to git
- When subclass is loaded earlier than superclass, there was a problem with dependency
- New way uses MCSnapshot object, that resolves dependencies between class definitions and classes are loaded in proper order