### PR TITLE
Enable test runner for Pharo track

### DIFF
--- a/config.json
+++ b/config.json
@@ -5,7 +5,7 @@
   "active": true,
   "status": {
     "concept_exercises": false,
-    "test_runner": false,
+    "test_runner": true,
     "representer": false,
     "analyzer": false
   },
@@ -29,6 +29,9 @@
     "exemplar": [
       ".meta/solution/%{pascal_slug}.class.st"
     ]
+  },
+  "test_runner": {
+    "average_run_time": 1.0
   },
   "exercises": {
     "concept": [],


### PR DESCRIPTION
This enables Test Runner for Pharo track.
Should be merged after (follow-up of): https://github.com/exercism/pharo-smalltalk-test-runner/pull/18