### PR TITLE
Fix exercise test generator

### DIFF
--- a/dev/src/ExercismDev/ExercismExerciseGenerator.class.st
+++ b/dev/src/ExercismDev/ExercismExerciseGenerator.class.st
@@ -357,6 +357,14 @@ ExercismExerciseGenerator >> generateTestVariableAccessors: testVariable in: aCl
 	
 ]
 
+{ #category : #initialization }
+ExercismExerciseGenerator >> initialize [ 
+	
+	super initialize.
+	"reset number of generated test classes"
+	self numberGenerated: 0.
+]
+
 { #category : #generation }
 ExercismExerciseGenerator >> isErrorAssertion: testResults [
 	testResults isDictionary ifFalse: [ ^false ].

--- a/dev/src/ExercismDev/ExercismExerciseGenerator.class.st
+++ b/dev/src/ExercismDev/ExercismExerciseGenerator.class.st
@@ -73,25 +73,14 @@ ExercismExerciseGenerator class >> writeLegacyPackageBaselineNames [
 
 { #category : #internal }
 ExercismExerciseGenerator >> compile: src for: aClass selector: aSelector protocol: aName [
-	| cm aContext |
 	
-	"aClass compile: src classified: (Protocol name: 'setup') notifying: self."
-	
-	aContext := CompilationContext new 
-		interactive: false; 
-		"forSyntaxHighlighting: true;"
-		"logged: false;"
-		yourself.
-	
-	cm := OpalCompiler new 
-					compilationContext: aContext;
-					options: #( + #optionEmbeddSources );				
-					class: aClass;
-					compile: src.
-			
+	"compiles method even with undeclared globals (solution class)"
+	aClass compile: src.
+
+	"categorize compiled method to proper protocol"
 	aClass 
 		addAndClassifySelector: aSelector
-		withMethod: cm
+		withMethod: (aClass compiledMethodAt: aSelector)
 		inProtocol: aName
 ]
 
@@ -187,12 +176,12 @@ ExercismExerciseGenerator >> generateExerciseFrom: aFileSystemReference [
 	(Smalltalk hasClassNamed: testName) ifTrue: [ ^self log: 'already exists (skipping)' for: testName ].
 	
 	testDescription := (aFileSystemReference / 'description.md') contents.
-	testMetaData := (aFileSystemReference / 'metadata.yml') contents.
+	testMetaData := (aFileSystemReference / 'metadata.toml') contents.
 	testSpecification := [ (aFileSystemReference / 'canonical-data.json') contents] 
 		on: FileDoesNotExistException do: [ ^self log:'has no specification (skipping)' for: testName ].
 		
 	testJson := STONJSON fromString: testSpecification.
-	versionString := testJson at: 'version'.
+	versionString := testJson at: 'version' ifAbsent: ['Not specified'].
 	
 	testMetaData := (WriteStream on: '') nextPutAll: testMetaData;
 		nextPutAll: ('exercise: "{1}"' format: {testRoot}); cr;
@@ -385,7 +374,7 @@ ExercismExerciseGenerator >> keywordFor: key withPrefix: aSelectorPrefix [
 { #category : #internal }
 ExercismExerciseGenerator >> log: stringMsg for: testNameString [
 
-	self crLog: testNameString, ' ', stringMsg
+	self traceCr: testNameString, ' ', stringMsg
 ]
 
 { #category : #accessing }

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -76,7 +76,7 @@ __From problem repository__
 - If you want to start completely new Practise exercise (step 1a.), you can use problem specification repository and generate test class for given exercise by running: 
 `ExercismExerciseGenerator generateFrom: <path-to-problem-specifications/exercises>` - this will generate test classes for all exercises in problem specifications repository in `ExerciseWIP` package.  
   > __Note__: You can use menu item in Pharo image for achieving same (World menu -> Exercism -> Generate test cases).
-- More specifically, you can generate test class for specific exercise by: `ExercismExerciseGenerator generateExerciseFrom: <path-to-problem-specifications/exercises/slug-name>`.
+- More specifically, you can generate test class for specific exercise by: `ExercismExerciseGenerator generateExerciseFrom: '<path-to-problem-specifications/exercises/slug-name>' asFileReference`.
 
 Result of previous statement will be new `<SlugNameTest>` (a subclass of ExercismTest) test class with generated test methods in `ExerciseWIP` package.
 


### PR DESCRIPTION
Following changes make Exercise test generator working again. Previously it resulted in error and therefore test classes cannot be generated from canonical descriptions.