### PR TITLE
Fixed dependency in project baseline to be loaded in P11

### DIFF
--- a/dev/src/BaselineOfExercism/BaselineOfExercism.class.st
+++ b/dev/src/BaselineOfExercism/BaselineOfExercism.class.st
@@ -70,7 +70,7 @@ BaselineOfExercism >> baseline: spec [
 			].
 			spec for: #'pharo11.x' do: [
 				"ExercismTools methods will add methods from compatibility package for Pharo 11"
-				spec package: 'ExercismTests' with: [ spec includes: #('ExercismPharo110') ].
+				spec package: 'ExercismTools' with: [ spec includes: #('ExercismPharo110') ].
 				spec package: 'ExercismPharo110'
 			].
 			spec for: #'pharo12.x' do: [


### PR DESCRIPTION
I used wrong package for dependency therefore fix was not applied / loaded for Pharo 11
- fixes #610 