### PR TITLE
Fix typos in `CircularBufferTest.class.st`

### DIFF
--- a/dev/src/Exercise@CircularBuffer/CircularBufferTest.class.st
+++ b/dev/src/Exercise@CircularBuffer/CircularBufferTest.class.st
@@ -45,7 +45,7 @@ Because there is space available, if the client again uses overwrite to store C 
     [C][D][7][8][9][A][B]
 
 ## Hint
-For error cases during operations, see Error class hiearchy (class side) to find out how to signal exception with given message.
+For error cases during operations, see Error class hierarchy (class side) to find out how to signal exception with given message.
 
 "
 Class {
@@ -60,7 +60,7 @@ Class {
 { #category : #config }
 CircularBufferTest class >> exercise [
 
-	^(ExercismExercise for: self) 
+	^(ExercismExercise for: self)
 		isCore: false;
 		isAutoApproved: true;
 		difficulty: 5;
@@ -90,7 +90,7 @@ CircularBufferTest >> setUp [
 CircularBufferTest >> test01_ReadingEmptyBufferShouldFail [
 	"Tip: Remember to review the class [Comment] tab"
 
-	<exeTestName: 'eading empty buffer should fail'>
+	<exeTestName: 'reading empty buffer should fail'>
 	<exeTestUUID: '28268ed4-4ff3-45f3-820e-895b44d53dfa'>
 	circularBufferCalculator capacity: 1.
 	self should: [circularBufferCalculator read] raise: Error.
@@ -144,7 +144,7 @@ CircularBufferTest >> test05_FullBufferCantBeWrittenTo [
 
 	<exeTestName: 'full buffer can''t be written to'>
 	<exeTestUUID: '2af22046-3e44-4235-bfe6-05ba60439d38'>
-	
+
 	circularBufferCalculator capacity: 1.
 	circularBufferCalculator write: 1.
 	self should: [ circularBufferCalculator write: 2 ] raise: Error
@@ -211,7 +211,7 @@ CircularBufferTest >> test09_ClearFreesUpCapacityForAnotherWrite [
 	| result |
 	circularBufferCalculator capacity: 1.
 	circularBufferCalculator write: 1.
-	
+
 	circularBufferCalculator clear.
 
 	circularBufferCalculator write: 2.

--- a/exercises/practice/circular-buffer/CircularBufferTest.class.st
+++ b/exercises/practice/circular-buffer/CircularBufferTest.class.st
@@ -45,7 +45,7 @@ Because there is space available, if the client again uses overwrite to store C 
     [C][D][7][8][9][A][B]
 
 ## Hint
-For error cases during operations, see Error class hiearchy (class side) to find out how to signal exception with given message.
+For error cases during operations, see Error class hierarchy (class side) to find out how to signal exception with given message.
 
 "
 Class {
@@ -90,7 +90,7 @@ CircularBufferTest >> setUp [
 CircularBufferTest >> test01_ReadingEmptyBufferShouldFail [
 	"Tip: Remember to review the class [Comment] tab"
 
-	<exeTestName: 'eading empty buffer should fail'>
+	<exeTestName: 'reading empty buffer should fail'>
 	<exeTestUUID: '28268ed4-4ff3-45f3-820e-895b44d53dfa'>
 	circularBufferCalculator capacity: 1.
 	self should: [circularBufferCalculator read] raise: Error.

--- a/exercises/practice/circular-buffer/CircularBufferTest.class.st
+++ b/exercises/practice/circular-buffer/CircularBufferTest.class.st
@@ -45,7 +45,7 @@ Because there is space available, if the client again uses overwrite to store C 
     [C][D][7][8][9][A][B]
 
 ## Hint
-For error cases during operations, see Error class hierarchy (class side) to find out how to signal exception with given message.
+For error cases during operations, see Error class hiearchy (class side) to find out how to signal exception with given message.
 
 "
 Class {
@@ -90,7 +90,7 @@ CircularBufferTest >> setUp [
 CircularBufferTest >> test01_ReadingEmptyBufferShouldFail [
 	"Tip: Remember to review the class [Comment] tab"
 
-	<exeTestName: 'reading empty buffer should fail'>
+	<exeTestName: 'eading empty buffer should fail'>
 	<exeTestUUID: '28268ed4-4ff3-45f3-820e-895b44d53dfa'>
 	circularBufferCalculator capacity: 1.
 	self should: [circularBufferCalculator read] raise: Error.


### PR DESCRIPTION
I noticed two typos in this test file.