### PR TITLE
Test class comment genration from various .md files

### DIFF
--- a/dev/src/ExercismDev/ExercismExerciseGenerator.class.st
+++ b/dev/src/ExercismDev/ExercismExerciseGenerator.class.st
@@ -471,8 +471,17 @@ ExercismExerciseGenerator >> testClassName [
 { #category : 'internal' }
 ExercismExerciseGenerator >> testDescription [ 
  
-	^ (self exerciseDirReference / 'description.md') contents
+	| descriptionFile | 
+	descriptionFile := self exerciseDirReference / 'description.md'.
+	descriptionFile isFile ifTrue: [ ^ descriptionFile contents].
 	
+	"if description.md is missing, use introduction.md and instructions.md (new way)"
+	^ String streamContents: [:aStream | 
+		aStream 
+			nextPutAll: (self exerciseDirReference / 'introduction.md') contents;
+			cr;
+			nextPutAll: (self exerciseDirReference / 'instructions.md') contents 
+	]
 ]
 
 { #category : 'internal' }

--- a/dev/src/ExercismTests/ExercismExerciseGeneratorTest.class.st
+++ b/dev/src/ExercismTests/ExercismExerciseGeneratorTest.class.st
@@ -98,6 +98,35 @@ ExercismExerciseGeneratorTest >> createMockExerciseDirectory [
 ]
 
 { #category : 'setup' }
+ExercismExerciseGeneratorTest >> createMockExerciseDirectoryWithInstructions [
+	|memFileRef exerciseDir |
+	memFileRef := FileSystem memory root.
+	exerciseDir := (memFileRef / 'mock-exercise') ensureCreateDirectory.
+	
+	"exercise description"
+	(exerciseDir / 'introduction.md')
+		ensureCreateFile;
+		writeStreamDo: [:aStream |
+			aStream << '# Introduction'; cr; cr.
+			aStream << 'Some introduction.'; cr.
+		].
+		(exerciseDir / 'instructions.md')
+		ensureCreateFile;
+		writeStreamDo: [:aStream |
+			aStream << '# Instructions'; cr; cr.
+			aStream << 'Some instructions.'; cr.
+		].
+	
+	"canonical test cases"
+	(exerciseDir / 'canonical-data.json')
+		ensureCreateFile;
+		writeStreamDo: [:aStream |
+			aStream << self canonicalTestSampleJson 
+		].
+	^ exerciseDir  
+]
+
+{ #category : 'setup' }
 ExercismExerciseGeneratorTest >> mockClassName [
 
 	^ ('mock-exercise' kebabAsCamelCase, 'Test') asSymbol
@@ -225,4 +254,16 @@ ExercismExerciseGeneratorTest >> testSetupAppendInfoFromExistingTestClass [
 	generator exerciseDirReference: 'mock-exercise' asFileReference.
 	generator setupAppendInfoFromExistingTestClass.
 	self assert: generator existingAppendInfo equals: 'TBD'.
+]
+
+{ #category : 'tests' }
+ExercismExerciseGeneratorTest >> testTestDescription [
+
+	|generator|
+	generator := ExercismExerciseGenerator new generateExerciseFrom: self createMockExerciseDirectory; yourself.
+	self assert: (generator testDescription includesSubstring: (String loremIpsum: 100)).
+	
+	generator := ExercismExerciseGenerator new generateExerciseFrom: self createMockExerciseDirectoryWithInstructions; yourself.
+	self assert: (generator testDescription includesSubstring: '# Introduction').
+	self assert: (generator testDescription includesSubstring: '# Instructions').
 ]


### PR DESCRIPTION
Changed test class comment generation either from instructions.md & introduction.md or description.md.
This is needed for geneerating exercise test classes in Pharo from problem specifications that don't specify description.md, but instead they use introduction.md and instructions.md.

Example using description.md: https://github.com/exercism/problem-specifications/tree/main/exercises/darts
Example using introduction.md and instructions.md: https://github.com/exercism/problem-specifications/tree/main/exercises/gigasecond