### PR TITLE
Sync exercise titles capitals

### DIFF
--- a/dev/src/Exercise@Etl/EtlTest.class.st
+++ b/dev/src/Exercise@Etl/EtlTest.class.st
@@ -74,6 +74,14 @@ EtlTest class >> exercise [
 ]
 
 { #category : 'config' }
+EtlTest class >> exerciseTitle [
+
+	"Answer the exercise title string, obtained from metadata.toml"
+	
+	^ 'OTL'
+]
+
+{ #category : 'config' }
 EtlTest class >> uuid [
 	"Answer a unique id for this exercise"
 	^'5bf981a0-0647-4867-9026-b25021b48a23'

--- a/dev/src/Exercise@IsbnVerifier/IsbnVerifierTest.class.st
+++ b/dev/src/Exercise@IsbnVerifier/IsbnVerifierTest.class.st
@@ -68,6 +68,14 @@ IsbnVerifierTest class >> exercise [
 ]
 
 { #category : 'config' }
+IsbnVerifierTest class >> exerciseTitle [
+
+	"Answer the exercise title string, obtained from metadata.toml"
+	
+	^ 'ISBN Verifier'
+]
+
+{ #category : 'config' }
 IsbnVerifierTest class >> uuid [
 	"Answer a unique id for this exercise"
 	^'9cb67bca-f8db-4bf6-b61e-d43318c821d7'

--- a/dev/src/Exercise@OcrNumbers/OcrNumbersTest.class.st
+++ b/dev/src/Exercise@OcrNumbers/OcrNumbersTest.class.st
@@ -112,6 +112,14 @@ OcrNumbersTest class >> exercise [
 ]
 
 { #category : 'config' }
+OcrNumbersTest class >> exerciseTitle [
+
+	"Answer the exercise title string, obtained from metadata.toml"
+	
+	^ 'OCR Numbers'
+]
+
+{ #category : 'config' }
 OcrNumbersTest class >> uuid [
 	"Answer a unique id for this exercise"
 	^'425b38ab-7fee-0d00-bc8f-b32e01817ff2'

--- a/dev/src/Exercise@OcrNumbers/OcrNumbersTest.class.st
+++ b/dev/src/Exercise@OcrNumbers/OcrNumbersTest.class.st
@@ -122,7 +122,7 @@ OcrNumbersTest class >> exerciseTitle [
 { #category : 'config' }
 OcrNumbersTest class >> uuid [
 	"Answer a unique id for this exercise"
-	^'425b38ab-7fee-0d00-bc8f-b32e01817ff2'
+	^'d586e915-466a-4806-8a00-7f325aabd493'
 ]
 
 { #category : 'config' }

--- a/dev/src/Exercise@SumOfMultiples/SumOfMultiplesTest.class.st
+++ b/dev/src/Exercise@SumOfMultiples/SumOfMultiplesTest.class.st
@@ -39,6 +39,14 @@ SumOfMultiplesTest class >> exercise [
 ]
 
 { #category : 'config' }
+SumOfMultiplesTest class >> exerciseTitle [
+
+	"Answer the exercise title string, obtained from metadata.toml"
+	
+	^ 'Sum of Multiples'
+]
+
+{ #category : 'config' }
 SumOfMultiplesTest class >> uuid [
 	"Answer a unique id for this exercise"
 	^'34b0900f-de21-4fef-b24b-f125b608e65e'

--- a/dev/src/Exercise@TwoFer/TwoFerTest.class.st
+++ b/dev/src/Exercise@TwoFer/TwoFerTest.class.st
@@ -56,6 +56,14 @@ TwoFerTest class >> exercise [
 ]
 
 { #category : 'config' }
+TwoFerTest class >> exerciseTitle [
+
+	"Answer the exercise title string, obtained from metadata.toml"
+	
+	^ 'Two-Fer'
+]
+
+{ #category : 'config' }
 TwoFerTest class >> uuid [
 	"Answer a unique id for this exercise"
 	^'9806fcc0-8505-4012-bd64-3f7468014df5'


### PR DESCRIPTION
Some exercise names (who use capital letter abbreviations) were out-of-sync with config.json. Now config.json should be generated according to titles in problem specifications.
Also fixed out-of-sync UUID of OCR Numbers exercise.